### PR TITLE
Remove redundant titles from the pull request and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,4 @@
-# Description
-
-[Description of the change]
+[Description of the issue]
 
 # Steps to reproduce
 You can omit this section if not applicable.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,3 @@
-# Description
-
 [Description of the change]
 
 **Status:** Ready / In development


### PR DESCRIPTION
This commit removes the unnecessary "Description" titles from the pull request and issue templates. Also it fixes a typo in the issue template.

**Status:** Ready

**Fixes:** N/A

