### PR TITLE
Build LLVM in the gramlang/gram:deps Docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,5 @@ services:
   - docker
 script:
   - make docker
+after_success:
   - docker run gramlang/gram gram -v

--- a/Dockerfile-gram
+++ b/Dockerfile-gram
@@ -1,11 +1,29 @@
 FROM gramlang/gram:deps
-MAINTAINER Stephan Boyer <stephan@stephanboyer.com>
+COPY . /root/gram
+RUN cd /root && \
 
-# Build and lint Gram.
-COPY . /home/gram
-RUN cd /home/gram && \
+  # Build and lint Gram.
+  cd gram && \
+  rm -rf build && \
+  mv ../build build && \
+  touch build/release/llvm/build/bin/llvm-config && \
   make && \
   make install && \
   make lint && \
   cd .. && \
-  rm -rf gram
+  rm -rf gram && \
+
+  # Remove build dependencies.
+  update-alternatives --remove clang /usr/bin/clang && \
+  update-alternatives --remove clang++ /usr/bin/clang++ && \
+  update-alternatives --remove scan-build /usr/bin/scan-build && \
+  DEBIAN_FRONTEND=noninteractive apt-get -y purge \
+  build-essential \
+  clang-4.0 \
+  cmake=3.6.2-1 \
+  cppcheck \
+  git \
+  perl \
+  shellcheck && \
+  DEBIAN_FRONTEND=noninteractive apt-get -y autoremove && \
+  rm -rf /var/lib/apt/lists/*

--- a/Dockerfile-gram-deps
+++ b/Dockerfile-gram-deps
@@ -1,35 +1,26 @@
-FROM ubuntu:16.04
-MAINTAINER Stephan Boyer <stephan@stephanboyer.com>
+FROM debian:jessie
+COPY . /root/gram
+RUN cd /root && \
 
-# Install GCC, CppCheck, ShellCheck, and Subversion.
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
+  # Install various dependencies from Debian.
+  echo 'deb http://httpredir.debian.org/debian sid main' >> /etc/apt/sources.list && \
+  DEBIAN_FRONTEND=noninteractive apt-get -y update && \
   DEBIAN_FRONTEND=noninteractive apt-get -y install \
   build-essential \
+  clang-4.0 \
+  cmake=3.6.2-1 \
   cppcheck \
-  shellcheck \
-  subversion
+  git \
+  perl \
+  shellcheck && \
+  rm -rf /var/lib/apt/lists/* && \
+  update-alternatives --install /usr/bin/clang clang /usr/bin/clang-4.0 100 && \
+  update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-4.0 100 && \
+  update-alternatives --install /usr/bin/scan-build scan-build /usr/bin/scan-build-4.0 100 && \
 
-# Delete all the apt list files since they're big and get stale quickly.
-RUN rm -rf /var/lib/apt/lists/*
-
-# Build and install CMake.
-COPY deps/cmake-3.5.2.tar.gz /home/cmake-3.5.2/cmake-3.5.2.tar.gz
-RUN cd /home/cmake-3.5.2 && \
-  tar -xf cmake-3.5.2.tar.gz -C . --strip-components=1 && \
-  ./bootstrap && \
-  make -j $(grep -c '^processor' /proc/cpuinfo) && \
-  make install && \
+  # Build LLVM for Gram.
+  cd gram && \
+  make build/release/llvm/build/bin/llvm-config && \
   cd .. && \
-  rm -rf cmake-3.5.2
-
-# Build and install Clang.
-RUN cd /home && \
-  svn co http://llvm.org/svn/llvm-project/llvm/trunk llvm && \
-  svn co http://llvm.org/svn/llvm-project/cfe/trunk llvm/tools/clang && \
-  mkdir clang && \
-  cd clang && \
-  cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release ../llvm && \
-  make -j $(grep -c '^processor' /proc/cpuinfo) && \
-  make install && \
-  cd .. && \
-  rm -rf llvm clang
+  mv gram/build build && \
+  rm -rf gram

--- a/Makefile
+++ b/Makefile
@@ -50,18 +50,17 @@ docker-deps: Dockerfile-gram-deps
 lint: $(addprefix src/,$(HEADERS)) $(addprefix src/,$(SOURCES)) \
 		$(BUILD_PREFIX)/llvm/build/bin/llvm-config
 	shellcheck scripts/*.sh
-	cppcheck src --enable=all --force --error-exitcode=1 \
+	cppcheck src --enable=all --force --error-exitcode=1 -j $(NPROCS) \
 		-I $(BUILD_PREFIX)/llvm/llvm/include \
 		-I $(BUILD_PREFIX)/llvm/build/include \
 		--suppressions-list=cppcheck-suppressions.txt
-	which scan-build 2> /dev/null && \
-		rm -f $(BUILD_PREFIX)/bin/gram && \
-		scan-build \
-			--status-bugs \
-			--use-analyzer $$(which clang) \
-			--use-cc $$(./scripts/get-compiler.sh CC) \
-			--use-c++ $$(./scripts/get-compiler.sh CXX) \
-			make $(BUILD_PREFIX)/bin/gram SCAN_BUILD=yes
+	rm -f $(BUILD_PREFIX)/bin/gram && \
+	scan-build \
+		--status-bugs \
+		--use-analyzer $$(which clang) \
+		--use-cc $$(./scripts/get-compiler.sh CC) \
+		--use-c++ $$(./scripts/get-compiler.sh CXX) \
+		make $(BUILD_PREFIX)/bin/gram SCAN_BUILD=yes
 
 install: all
 	cp $(addprefix $(BUILD_PREFIX)/bin/,$(TARGETS)) $(PREFIX)


### PR DESCRIPTION
Currently, the `gramlang/gram` image takes about an hour to build in Travis CI. The vast majority of that time is spent building LLVM. This change moves the LLVM build into `gramlang/gram:deps`. This image changes infrequently and is not built in Travis CI, so the CI jobs should run much faster now.

**Status:** Ready

**Fixes:** N/A