### PR TITLE
Only push gramlang/gram:latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,5 @@ after_success:
   - test "$TRAVIS_PULL_REQUEST" = "false" &&
     test "$TRAVIS_BRANCH" = "master" &&
     docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD" &&
-    docker push gramlang/gram ||
+    docker push gramlang/gram:latest ||
     true


### PR DESCRIPTION
There was a subtle bug introduced in https://github.com/gramlang/gram/pull/10 where the final build step would push the whole Docker repository, not just the `latest` tag. This change fixes that.

**Status:** Ready

**Fixes:** N/A

