### PR TITLE
Require the Docker push to succeed for master builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,12 @@ sudo: required
 services:
   - docker
 script:
-  - make docker-gram-build && make docker-gram && docker run gramlang/gram gram -v
-after_success:
-  - test "$TRAVIS_PULL_REQUEST" = "false" &&
-    test "$TRAVIS_BRANCH" = "master" &&
-    docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD" &&
-    docker push gramlang/gram:latest ||
-    true
+  - make docker-gram-build &&
+    make docker-gram &&
+    docker run gramlang/gram gram -v && (
+      test "$TRAVIS_PULL_REQUEST" != "false" ||
+      test "$TRAVIS_BRANCH" != "master" || (
+        docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD" &&
+        docker push gramlang/gram:latest
+      )
+    )


### PR DESCRIPTION
Previously, master builds could pass even if the final `docker push` failed. Now we make the whole build fail if the push was unsuccessful.

**Status:** Ready

**Fixes:** N/A

