### PR TITLE
Use scratch instead of debian:jessie for the final Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+build/debug
+build/release

--- a/Dockerfile-gram
+++ b/Dockerfile-gram
@@ -1,2 +1,2 @@
-FROM debian:jessie
-COPY build/release/bin/gram-docker /usr/local/bin/gram
+FROM scratch
+COPY build/gram-docker /usr/local/bin/gram

--- a/Makefile
+++ b/Makefile
@@ -41,10 +41,10 @@ clean-all:
 docker-gram:
 	mkdir -p build/release/bin
 	export CONTAINER=$$(docker create gramlang/gram:build) && \
-		docker cp $$CONTAINER:/usr/local/bin/gram build/release/bin/gram-docker && \
+		docker cp $$CONTAINER:/usr/local/bin/gram build/gram-docker && \
 		docker rm $$CONTAINER
 	docker build -f Dockerfile-gram -t gramlang/gram .
-	rm build/release/bin/gram-docker
+	rm build/gram-docker
 
 docker-gram-build:
 	docker build -f Dockerfile-gram-build -t gramlang/gram:build .


### PR DESCRIPTION
Use `scratch` instead of `debian:jessie` for the final Docker image. This should make the image much smaller. Also, add a `.dockerignore` file.

**Status:** Ready

**Fixes:** N/A

