### PR TITLE
Fix a bug in the `make lint` rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,8 +67,8 @@ lint: $(addprefix src/,$(HEADERS)) $(addprefix src/,$(SOURCES)) \
 	scan-build \
 		--status-bugs \
 		--use-analyzer $$(which clang) \
-		--use-cc $CC \
-		--use-c++ $CXX \
+		--use-cc $(CC) \
+		--use-c++ $(CXX) \
 		make $(BUILD_PREFIX)/bin/gram
 
 install: all


### PR DESCRIPTION
Fix a bug in the `make lint` rule.

**Status:** Ready

**Fixes:** N/A

