### PR TITLE
Disable terminfo to eliminate the dependency on ncurses

### DIFF
--- a/Dockerfile-gram-deps
+++ b/Dockerfile-gram-deps
@@ -11,7 +11,6 @@ RUN cd /root && \
   cmake=3.6.2-1 \
   cppcheck \
   git \
-  libncurses5-dev \
   perl \
   shellcheck && \
   rm -rf /var/lib/apt/lists/* && \

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ $(BUILD_PREFIX)/bin/gram: $(addprefix src/,$(HEADERS)) $(addprefix src/,$(SOURCE
 	$(CXX) $(addprefix src/,$(SOURCES)) $(BUILD_PREFIX)/gram/version.cpp \
 		-o $(BUILD_PREFIX)/bin/gram \
 		$(shell $(BUILD_PREFIX)/llvm/build/bin/llvm-config --cxxflags --ldflags --libs --system-libs) \
-		$$( (uname -s | grep -qi 'Darwin') || echo -static) -lncurses -static-libstdc++
+		$$( (uname -s | grep -qi 'Darwin') || echo -static) -static-libstdc++
 
 $(BUILD_PREFIX)/llvm/build/bin/llvm-config: deps/llvm-3.9.0.src.tar.xz
 	rm -rf $(BUILD_PREFIX)/llvm
@@ -98,5 +98,6 @@ $(BUILD_PREFIX)/llvm/build/bin/llvm-config: deps/llvm-3.9.0.src.tar.xz
 		-DCMAKE_C_COMPILER=$(CC) \
 		-DCMAKE_CXX_COMPILER=$(CXX) \
 		-DLLVM_ENABLE_EH=ON \
-		-DLLVM_ENABLE_RTTI=ON
+		-DLLVM_ENABLE_RTTI=ON \
+		-DLLVM_ENABLE_TERMINFO=OFF
 	cd $(BUILD_PREFIX)/llvm/build && make -j $(NPROCS)


### PR DESCRIPTION
Disable terminfo to eliminate the dependency on ncurses.

**Status:** Ready

**Fixes:** N/A

