### PR TITLE
Refactor to use raw indices rather than line/col numbers

### DIFF
--- a/src/error.cpp
+++ b/src/error.cpp
@@ -6,30 +6,63 @@ gram::Error::Error(std::string message) : message(message) {
 gram::Error::Error(
   std::string message,
   const std::string &source, std::string source_name,
-  size_t start_line, size_t start_col,
-  size_t end_line, size_t end_col
+  size_t start_pos, size_t end_pos
 ) {
-  this->message = source_name +
-    ":" + std::to_string(start_line + 1) +
-    ":" + std::to_string(start_col + 1) + "\n" + message;
-
-  // Try to find the line(s) from the source by the line numbers.
+  // Compute line numbers, column numbers, and context boundaries.
+  size_t start_line = 0;
+  size_t start_col = 0;
+  size_t end_line = 0;
+  size_t end_col = 0;
+  size_t context_start_pos = 0;
+  size_t context_end_pos = source.size();
   size_t line_number = 0;
-  size_t start_pos = 0;
-  size_t end_pos = source.size();
-  for (size_t pos = 0; pos < source.size(); ++pos) {
-    if (source[pos] == '\n') {
+  size_t col_number = 0;
+  bool found_start = false;
+  bool found_end = false;
+  for (size_t pos = 0; pos <= source.size(); ++pos) {
+    if (pos == start_pos) {
+      start_line = line_number;
+      start_col = col_number;
+      found_start = true;
+    }
+    if (pos == end_pos) {
+      end_line = line_number;
+      end_col = col_number;
+      found_end = true;
+    }
+    if (pos == source.size() || source[pos] == '\n') {
       ++line_number;
-      if (line_number == start_line) {
-        start_pos = pos + 1;
+      col_number = 0;
+      if (!found_start) {
+        context_start_pos = pos + 1;
       }
-      if (line_number == end_line + 1) {
-        end_pos = pos;
+      if (found_end) {
+        context_end_pos = pos;
         break;
       }
+    } else {
+      ++col_number;
     }
   }
-  auto context = source.substr(start_pos, end_pos - start_pos);
+  auto context = source.substr(
+    context_start_pos,
+    context_end_pos - context_start_pos
+  );
+
+  // Output the source name, position, and message.
+  if (end_pos == start_pos || end_pos == start_pos + 1) {
+    this->message = source_name +
+      " @ " + std::to_string(start_line + 1) +
+      ":" + std::to_string(start_col + 1) +
+      "\n" + message;
+  } else {
+    this->message = source_name +
+      " @ " + std::to_string(start_line + 1) +
+      ":" + std::to_string(start_col + 1) +
+      " - " + std::to_string(end_line + 1) +
+      ":" + std::to_string(end_col) +
+      "\n" + message;
+  }
 
   // Check if the context has only whitespace.
   auto only_whitespace = true;

--- a/src/error.h
+++ b/src/error.h
@@ -9,13 +9,6 @@
 
 namespace gram {
 
-  // Notes about line and column numbering (also noted in lexer.h):
-  // - Line feeds exist on the lines they are terminating,
-  //   not the following line.
-  // - All indices must point to a valid character, with one exception:
-  //   the end of the file is represented by the last column number + 1,
-  //   with no change to the line number.
-
   class Error {
   private:
     std::string message;
@@ -23,12 +16,13 @@ namespace gram {
   public:
     explicit Error(std::string message);
     explicit Error(
-      std::string message,
-      const std::string &source, std::string source_name,
-      size_t start_line, size_t start_col, // Zero-indexed, inclusive
-      size_t end_line, size_t end_col // Zero-indexed, exclusive
+      std::string message, // No trailing line break
+      const std::string &source,
+      std::string source_name,
+      size_t start_pos, // Inclusive
+      size_t end_pos // Exclusive
     );
-    std::string what();
+    std::string what(); // No trailing line break
   };
 
 }

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -35,28 +35,20 @@ namespace gram {
     "THIN_ARROW"
   };
 
-  // Notes about line and column numbering (also noted in error.h):
-  // - Line feeds exist on the lines they are terminating,
-  //   not the following line.
-  // - All indices must point to a valid character, with one exception:
-  //   the end of the file is represented by the last column number + 1,
-  //   with no change to the line number.
-
   class Token {
   public:
     gram::TokenType type;
     std::string literal;
     std::shared_ptr<std::string> source_name;
     std::shared_ptr<std::string> source;
-    size_t start_line, start_col, // Zero-indexed, inclusive
-      end_line, end_col; // Zero-indexed, exclusive
+    size_t start_pos; // Inclusive
+    size_t end_pos; // Exclusive
 
     Token(
       gram::TokenType type, const std::string &literal,
       std::shared_ptr<std::string> source_name,
       std::shared_ptr<std::string> source,
-      size_t start_line, size_t start_col,
-      size_t end_line, size_t end_col
+      size_t start_pos, size_t end_pos
     );
     std::string show();
   };

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -19,10 +19,8 @@ void gram::Node::span_tokens(
   if (begin < end) {
     source_name = begin->source_name;
     source = begin->source;
-    start_line = begin->start_line;
-    start_col = begin->start_col;
-    end_line = (end - 1)->end_line;
-    end_col = (end - 1)->end_col;
+    start_pos = begin->start_pos;
+    end_pos = (end - 1)->end_pos;
   }
 }
 
@@ -339,18 +337,14 @@ std::shared_ptr<gram::Term> parse_term(
 
   // Application (we use the foldl method to parse with left-associativity)
   if (prior_term && term) {
-    auto start_line = prior_term->start_line;
-    auto start_col = prior_term->start_col;
-    auto end_line = term->end_line;
-    auto end_col = term->end_col;
+    auto start_pos = prior_term->start_pos;
+    auto end_pos = term->end_pos;
     auto application = std::make_shared<gram::Application>(
       prior_term,
       term
     );
-    application->start_line = start_line;
-    application->start_col = start_col;
-    application->end_line = end_line;
-    application->end_col = end_col;
+    application->start_pos = start_pos;
+    application->end_pos = end_pos;
     term = parse_term(next, end, next, application, memo);
   } else {
     if (prior_term && !term) {
@@ -447,8 +441,7 @@ std::shared_ptr<gram::Term> parse_abstraction_or_arrow_type(
         "This looks like the beginning of an abstraction or arrow type, "
           "but there is no arrow.",
         *(begin->source), *(begin->source_name),
-        begin->start_line, begin->start_col,
-        (begin + 1)->end_line, (begin + 1)->end_col
+        begin->start_pos, (begin + 1)->end_pos
       );
     }
 
@@ -463,8 +456,7 @@ std::shared_ptr<gram::Term> parse_abstraction_or_arrow_type(
       throw gram::Error(
         "Expected a type annotation here.",
         *(pos->source), *(pos->source_name),
-        pos->start_line, pos->start_col,
-        pos->end_line, pos->end_col
+        pos->start_pos, pos->end_pos
       );
     }
   }
@@ -477,8 +469,7 @@ std::shared_ptr<gram::Term> parse_abstraction_or_arrow_type(
     throw gram::Error(
       "Expected an arrow here.",
       *(pos->source), *(pos->source_name),
-      pos->start_line, pos->start_col,
-      pos->end_line, pos->end_col
+      pos->start_pos, pos->end_pos
     );
   }
   bool thin_arrow = (pos->type == gram::TokenType::THIN_ARROW);
@@ -489,8 +480,7 @@ std::shared_ptr<gram::Term> parse_abstraction_or_arrow_type(
     throw gram::Error(
       "Missing body for abstraction or arrow type of '" + argument_name + "'.",
       *((pos - 1)->source), *((pos - 1)->source_name),
-      (pos - 1)->start_line, (pos - 1)->start_col,
-      (pos - 1)->end_line, (pos - 1)->end_col
+      (pos - 1)->start_pos, (pos - 1)->end_pos
     );
   }
   auto body = parse_term(
@@ -504,8 +494,7 @@ std::shared_ptr<gram::Term> parse_abstraction_or_arrow_type(
     throw gram::Error(
       "Missing body for abstraction or arrow type of '" + argument_name + "'.",
       *(pos->source), *(pos->source_name),
-      pos->start_line, pos->start_col,
-      pos->end_line, pos->end_col
+      pos->start_pos, pos->end_pos
     );
   }
 
@@ -644,8 +633,7 @@ std::shared_ptr<gram::Term> parse_block(
       throw gram::Error(
         "Unexpected token encountered here.",
         *(pos->source), *(pos->source_name),
-        pos->start_line, pos->start_col,
-        pos->end_line, pos->end_col
+        pos->start_pos, pos->end_pos
       );
     }
 
@@ -662,8 +650,7 @@ std::shared_ptr<gram::Term> parse_block(
       throw gram::Error(
         "A block must end with a term.",
         *(pos->source), *(pos->source_name),
-        pos->start_line, pos->start_col,
-        pos->end_line, pos->end_col
+        pos->start_pos, pos->end_pos
       );
     }
   }
@@ -671,8 +658,7 @@ std::shared_ptr<gram::Term> parse_block(
     throw gram::Error(
       "A block must end with a term.",
       *(pos->source), *(pos->source_name),
-      body.back()->start_line, body.back()->start_col,
-      body.back()->end_line, body.back()->end_col
+      body.back()->start_pos, body.back()->end_pos
     );
   }
 
@@ -738,8 +724,7 @@ std::shared_ptr<gram::Node> parse_definition(
     throw gram::Error(
       "Missing definition of '" + variable_name + "'.",
       *((pos - 1)->source), *((pos - 1)->source_name),
-      (pos - 1)->start_line, (pos - 1)->start_col,
-      (pos - 1)->end_line, (pos - 1)->end_col
+      (pos - 1)->start_pos, (pos - 1)->end_pos
     );
   }
   auto body = parse_term(
@@ -753,8 +738,7 @@ std::shared_ptr<gram::Node> parse_definition(
     throw gram::Error(
       "Unexpected token encountered here.",
       *(pos->source), *(pos->source_name),
-      pos->start_line, pos->start_col,
-      pos->end_line, pos->end_col
+      pos->start_pos, pos->end_pos
     );
   }
 
@@ -822,8 +806,7 @@ std::shared_ptr<gram::Node> gram::parse(std::vector<gram::Token> &tokens) {
     throw gram::Error(
       "Unexpected token encountered here.",
       *(next->source), *(next->source_name),
-      next->start_line, next->start_col,
-      next->end_line, next->end_col
+      next->start_pos, next->end_pos
     );
   }
 

--- a/src/parser.h
+++ b/src/parser.h
@@ -15,8 +15,8 @@ namespace gram {
   public:
     std::shared_ptr<std::string> source_name;
     std::shared_ptr<std::string> source;
-    size_t start_line, start_col, // Zero-indexed, inclusive
-      end_line, end_col; // Zero-indexed, exclusive
+    size_t start_pos; // Inclusive
+    size_t end_pos; // Exclusive
 
     virtual ~Node();
     virtual std::string show() = 0;
@@ -26,10 +26,8 @@ namespace gram {
     // assumed to be from the same source file:
     // - source_name
     // - source
-    // - start_line
-    // - start_col
-    // - end_line
-    // - end_col
+    // - start_pos
+    // - end_pos
     void span_tokens(
       std::vector<gram::Token>::iterator begin,
       std::vector<gram::Token>::iterator end


### PR DESCRIPTION
Refactor to use raw indices rather than line/col numbers.

Also, fix a bug that would cause an identifier to be lexed incorrectly if it contains a non-ASCII code point anywhere but at the first position.

**Status:** Ready

**Fixes:** N/A