### PR TITLE
Use fully-qualified compiler paths and rename typer to typechecker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ override HEADERS := \
 	parser.h \
 	platform.h \
 	tokens.h \
-	typer.h \
+	typechecker.h \
 	version.h
 override SOURCES := \
 	ast.cpp \
@@ -38,7 +38,7 @@ override SOURCES := \
 	parser.cpp \
 	platform.cpp \
 	tokens.cpp \
-	typer.cpp
+	typechecker.cpp
 
 # The default targets to build relative to the $(BUILD_PREFIX)/dist directory.
 # These will be installed relative to the $(PREFIX) directory.
@@ -182,7 +182,7 @@ $(BUILD_PREFIX)/dist/bin/gram: \
 
 # This target builds LLVM, which is a dependency for Gram.
 $(BUILD_PREFIX)/llvm/dist/bin/llvm-config: deps/llvm-3.9.0.src.tar.xz
-	[ -n "$(CC)" -a -n "$(CXX)" ]
+	[ -n "$(CC)" -a -n "$(CXX)" ] # Ensure we have sufficient C and C++ compilers.
 	rm -rf $(BUILD_PREFIX)/llvm
 	mkdir -p $(BUILD_PREFIX)/llvm/src
 	tar -xf deps/llvm-3.9.0.src.tar.xz -C $(BUILD_PREFIX)/llvm/src \

--- a/scripts/get-compiler.sh
+++ b/scripts/get-compiler.sh
@@ -7,7 +7,7 @@ set -eu -o pipefail
 #   ./get-compiler.sh CC
 #   ./get-compiler.sh CXX
 
-if ! echo "$1" | grep -qi 'CC\|CXX'; then
+if ! echo "$1" | grep -qi '^\(CC\|CXX\)$'; then
   echo 'The argument must be CC or CXX.' >&2
   exit 1
 fi
@@ -15,22 +15,22 @@ fi
 # Clang >= 3.1
 if (clang --version 2> /dev/null | grep -qi ' \(3\.[1-9]\|[4-9]\.\)') &&
   clang++ --version 2> /dev/null | grep -qi ' \(3\.[1-9]\|[4-9]\.\)'; then
-  if echo "$1" | grep -qi 'CC'; then echo clang; exit; fi
-  if echo "$1" | grep -qi 'CXX'; then echo clang++; exit; fi
+  if echo "$1" | grep -qi 'CC'; then which clang; exit; fi
+  if echo "$1" | grep -qi 'CXX'; then which clang++; exit; fi
 fi
 
 # Clang that ships with Xcode >= 5.0, based on Clang >= 3.3
 if (clang --version 2> /dev/null | grep -qi 'apple llvm version [5-9]\.') &&
   clang++ --version 2> /dev/null | grep -qi 'apple llvm version [5-9]\.'; then
-  if echo "$1" | grep -qi 'CC'; then echo clang; exit; fi
-  if echo "$1" | grep -qi 'CXX'; then echo clang++; exit; fi
+  if echo "$1" | grep -qi 'CC'; then which clang; exit; fi
+  if echo "$1" | grep -qi 'CXX'; then which clang++; exit; fi
 fi
 
 # GCC >= 4.7
 if (gcc --version 2> /dev/null | grep -qi ' \(4\.7\.\|[5-9]\.\)') &&
   (g++ --version 2> /dev/null | grep -qi ' \(4\.7\.\|[5-9]\.\)'); then
-  if echo "$1" | grep -qi 'CC'; then echo gcc; exit; fi
-  if echo "$1" | grep -qi 'CXX'; then echo g++; exit; fi
+  if echo "$1" | grep -qi 'CC'; then which gcc; exit; fi
+  if echo "$1" | grep -qi 'CXX'; then which g++; exit; fi
 fi
 
 # If we made it this far, we were unable to determine the compiler.

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -11,9 +11,9 @@ set -eu -o pipefail
 VERSION='0.0.1'
 
 # Get the build type (release or debug).
-if echo "$1" | grep -qi 'release'; then
+if echo "$1" | grep -qi '^release$'; then
   BUILD_TYPE='release'
-elif echo "$1" | grep -qi 'debug'; then
+elif echo "$1" | grep -qi '^debug$'; then
   BUILD_TYPE='debug'
 else
   echo "BUILD_TYPE must be 'release' or 'debug'" >&2

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -3,7 +3,7 @@
 #include "lexer.h"
 #include "parser.h"
 #include "platform.h"
-#include "typer.h"
+#include "typechecker.h"
 #include <fstream>
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/LLVMContext.h>
@@ -61,7 +61,7 @@ void gram::compile(
 
   // Perform type checking and inference.
   if (node) {
-    type(*node);
+    typecheck(*node);
   }
 
   // Output the types, if requested.

--- a/src/typechecker.cpp
+++ b/src/typechecker.cpp
@@ -1,0 +1,6 @@
+#include "error.h"
+#include "typechecker.h"
+
+void gram::typecheck(gram::Node &node) {
+  // Perform type inference and checking.
+}

--- a/src/typechecker.h
+++ b/src/typechecker.h
@@ -2,15 +2,15 @@
   This header declares the interface to the type checker and inferencer.
 */
 
-#ifndef GRAM_TYPER_H
-#define GRAM_TYPER_H
+#ifndef GRAM_TYPECHECKER_H
+#define GRAM_TYPECHECKER_H
 
 #include "parser.h"
 
 namespace gram {
 
   // Perform type inference and checking.
-  void type(gram::Node &node);
+  void typecheck(gram::Node &node);
 
 }
 

--- a/src/typer.cpp
+++ b/src/typer.cpp
@@ -1,6 +1,0 @@
-#include "error.h"
-#include "typer.h"
-
-void gram::type(gram::Node &node) {
-  // Perform type inference and checking.
-}


### PR DESCRIPTION
Use fully-qualified compiler paths and rename `typer` to `typechecker`.

**Status:** Ready

**Fixes:** N/A
