### PR TITLE
Refactor the Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
+# This directory is sometimes generated during `make docs`.
+.sass-cache
+
+# Build artifacts are written here.
 build

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: required
 services:
   - docker
 install:
-  - gem install github-pages -v 108
+  - gem install github-pages -v 111
 script:
   - make docs &&
     make docker-gram-build &&

--- a/docker/Dockerfile-gram-build
+++ b/docker/Dockerfile-gram-build
@@ -6,6 +6,7 @@ RUN cd /root && \
   cd gram && \
   rm -rf build && \
   mv ../build build && \
-  touch build/release/llvm/dist/bin/llvm-config && \
-  make && \
-  make lint
+  touch build/release/llvm && \
+  make lint && \
+  make clean && \
+  make

--- a/docker/Dockerfile-gram-deps
+++ b/docker/Dockerfile-gram-deps
@@ -9,7 +9,7 @@ RUN cd /root && \
   DEBIAN_FRONTEND=noninteractive apt-get -y install \
   build-essential \
   clang-4.0 \
-  cmake=3.6.2-1 \
+  cmake>=3.7.1-1 \
   git \
   ninja-build \
   shellcheck && \
@@ -23,7 +23,7 @@ RUN cd /root && \
 
   # Build LLVM for Gram.
   cd gram && \
-  make build/release/llvm/dist/bin/llvm-config && \
+  make build/release/llvm && \
   cd .. && \
   mv gram/build build && \
   rm -rf gram

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,3 +1,0 @@
-_site
-.sass-cache
-.jekyll-metadata


### PR DESCRIPTION
Refactor the Makefile. This PR includes the following changes:

- [x] Update `github-pages` in CI
- [x] The `Makefile` no longer lists each source file explicitly (easier to maintain)
- [x] A new `BUILD_PREFIX_COMMON` path for targets which are the same in release/debug mode
- [x] `make docs` now puts build artifacts in the `build` directory
- [x] `make docs` will now do nothing if the docs build is already up-to-date
- [x] Relevant updates to `.gitignore` files

**Status:** Ready

**Fixes:** N/A
