### PR TITLE
Refactor the line length checker

### DIFF
--- a/docker/Dockerfile-gram-build
+++ b/docker/Dockerfile-gram-build
@@ -8,11 +8,8 @@ RUN cd /root && \
   mv ../build build && \
   touch build/release/llvm && \
 
-  # Build and lint Gram. Notes:
-  # - We run `make clean` because we don't trust the binary produced by the
-  #   Clang Static Analyzer during `make lint`.
-  # - We run `make docs` in a login shell (bash -l) because the Ruby
-  #   installation only works in login shells. This is due to RVM.
-  make lint && make clean && \
+  # Build and lint Gram. We run `make docs` in a login shell (bash -l) because
+  # the Ruby installation only works in login shells. This is due to RVM.
+  make lint && \
   bash -l -c 'make docs' && \
   make

--- a/scripts/check-line-lengths.sh
+++ b/scripts/check-line-lengths.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+# This script checks that lines in the given file(s) are at most 80 bytes,
+# including newline characters. It prints violations to standard output.
+
+# Usage:
+#   ./check-line-lengths.sh file1 file2 ...
+
+export LINE_LENGTH_VIOLATIONS
+
+LINE_LENGTH_VIOLATIONS="$( \
+  awk '{ if (length > 79) { print length, FILENAME, "@", FNR }}' "$@" \
+)"
+
+echo "$LINE_LENGTH_VIOLATIONS"
+
+if ! test -z "$LINE_LENGTH_VIOLATIONS"; then
+  exit 1
+fi

--- a/scripts/get-compiler.sh
+++ b/scripts/get-compiler.sh
@@ -2,6 +2,7 @@
 set -eu -o pipefail
 
 # This script tries to find a version of Clang >= 3.1 or GCC >= 4.7.
+# It returns the absolute path to the compiler.
 
 # Usage:
 #   ./get-compiler.sh CC


### PR DESCRIPTION
Refactor the line length checker into a standalone script. It now prints violations.

**Status:** Ready

**Fixes:** N/A
