### PR TITLE
Add error checking for redundant separators

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -122,7 +122,7 @@ std::string gram::Group::show() {
     if (first) {
       first = false;
     } else {
-      result += "; ";
+      result += ", ";
     }
     result += term ? term->show() : "<null>";
   }

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -11,7 +11,7 @@ std::unique_ptr<std::vector<gram::Token>> gram::lex(
   std::shared_ptr<std::string> source_name,
   std::shared_ptr<std::string> source
 ) {
-  std::vector<Token> tokens;
+  std::unique_ptr<std::vector<Token>> tokens(new std::vector<Token>);
   size_t pos = 0;
   std::vector<Token> grouping_stack;
   LineContinuationStatus line_continuation_status =
@@ -57,11 +57,12 @@ std::unique_ptr<std::vector<gram::Token>> gram::lex(
     // there was a line continuation marker.
     if ((*source)[pos] == '\n') {
       if (line_continuation_status == LineContinuationStatus::LCS_DEFAULT) {
-        tokens.push_back(Token(
+        tokens->push_back(Token(
           TokenType::SEPARATOR, "",
           source_name, source,
           pos, pos
         ));
+        tokens->back().explicit_separator = false;
       }
       if (
         line_continuation_status ==
@@ -112,7 +113,7 @@ std::unique_ptr<std::vector<gram::Token>> gram::lex(
         ++end_pos;
       }
       size_t length = end_pos - pos;
-      tokens.push_back(Token(
+      tokens->push_back(Token(
         TokenType::IDENTIFIER, source->substr(pos, length),
         source_name, source,
         pos, end_pos
@@ -156,7 +157,7 @@ std::unique_ptr<std::vector<gram::Token>> gram::lex(
         if (opener) {
           grouping_stack.push_back(token);
         }
-        tokens.push_back(token);
+        tokens->push_back(token);
         pos += literal.size();
         return true;
       }
@@ -247,8 +248,9 @@ std::unique_ptr<std::vector<gram::Token>> gram::lex(
 
     // SEPARATOR
     if (parse_symbol(
-      TokenType::SEPARATOR, ";", false, false, static_cast<TokenType>(0)
+      TokenType::SEPARATOR, ",", false, false, static_cast<TokenType>(0)
     )) {
+      tokens->back().explicit_separator = true;
       continue;
     }
 
@@ -269,56 +271,6 @@ std::unique_ptr<std::vector<gram::Token>> gram::lex(
     );
   }
 
-  // Filter out unnecessary SEPARATOR tokens.
-  auto filtered_tokens = std::unique_ptr<std::vector<Token>>(
-    new std::vector<Token>
-  );
-  for (auto iter = tokens.begin(); iter != tokens.end(); ++iter) {
-    // If we have a SEPARATOR token, do some tests to see if we can skip it.
-    if (iter->type == TokenType::SEPARATOR) {
-      // Skip redundant SEPARATOR tokens.
-      if (
-        (iter + 1) != tokens.end() &&
-        (iter + 1)->type == TokenType::SEPARATOR
-      ) {
-        continue;
-      }
-
-      // Don't add SEPARATOR tokens at the beginning.
-      if (filtered_tokens->empty()) {
-        continue;
-      }
-
-      // Don't add SEPARATOR tokens at the end.
-      if ((iter + 1) == tokens.end()) {
-        continue;
-      }
-
-      // Don't add SEPARATOR tokens after a group opener.
-      auto next_token = *(iter + 1);
-      if (
-        next_token.type == TokenType::RIGHT_CURLY ||
-        next_token.type == TokenType::RIGHT_PAREN ||
-        next_token.type == TokenType::RIGHT_SQUARE
-      ) {
-        continue;
-      }
-
-      // Don't add SEPARATOR tokens before a group closer.
-      auto prev_token = filtered_tokens->back();
-      if (
-        prev_token.type == TokenType::LEFT_CURLY ||
-        prev_token.type == TokenType::LEFT_PAREN ||
-        prev_token.type == TokenType::LEFT_SQUARE
-      ) {
-        continue;
-      }
-    }
-
-    // Add the token to the filtered vector.
-    filtered_tokens->push_back(*iter);
-  }
-
   // Return an std::unique_ptr to the vector.
-  return filtered_tokens;
+  return tokens;
 }

--- a/src/tokens.h
+++ b/src/tokens.h
@@ -51,6 +51,8 @@ namespace gram {
     size_t start_pos; // Inclusive
     size_t end_pos; // Exclusive
 
+    bool explicit_separator; // Only used for SEPARATOR tokens
+
     Token(
       gram::TokenType type, const std::string &literal,
       std::shared_ptr<std::string> source_name,


### PR DESCRIPTION
Add error checking for redundant separators. Also change the separator literal from `;` to `,`.

**Status:** Ready

**Fixes:** N/A
