### PR TITLE
Build the formal specification in the gram:build container

### DIFF
--- a/docker/Dockerfile-gram-build
+++ b/docker/Dockerfile-gram-build
@@ -11,4 +11,5 @@ RUN cd /root && \
   # Build and lint Gram.
   make lint && \
   make docs && \
+  make spec && \
   make

--- a/docker/Dockerfile-gram-deps
+++ b/docker/Dockerfile-gram-deps
@@ -11,7 +11,8 @@ RUN cd /root && \
 
   # Install various packages.
   # `ruby2.3`, `ruby2.3-dev`, and `zlib1g-dev` are needed for the
-  # `github-pages` gem (installed below).
+  # `github-pages` gem (installed below). `texlive-full` is needed
+  # for building the formal specification.
   DEBIAN_FRONTEND=noninteractive apt-get -y install \
   build-essential \
   clang-4.0 \
@@ -21,6 +22,7 @@ RUN cd /root && \
   ruby2.3 \
   ruby2.3-dev \
   shellcheck \
+  texlive-full \
   zlib1g-dev && \
   rm -rf /var/lib/apt/lists/* && \
   update-alternatives --install /usr/bin/clang clang \


### PR DESCRIPTION
Build the formal specification in the `gram:build` container (and therefore in CI as well).

/cc @ewang12

**Status:** Ready

**Fixes:** N/A
