### PR TITLE
Add a post-build step to upload the spec to S3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,13 @@ script:
         docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD" &&
         docker push gramlang/gram:deps &&
         docker push gramlang/gram:build &&
-        docker push gramlang/gram:latest
+        docker push gramlang/gram:latest &&
+        docker run
+          -e "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION"
+          -e "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID"
+          -e "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY"
+          -it gramlang/gram:build aws s3 cp --acl public-read
+          /root/gram/build/common/spec/gram.pdf
+          s3://static.gram.org/
       )
     )

--- a/docker/Dockerfile-gram-deps
+++ b/docker/Dockerfile-gram-deps
@@ -12,13 +12,17 @@ RUN cd /root && \
   # Install various packages.
   # `ruby2.3`, `ruby2.3-dev`, and `zlib1g-dev` are needed for the
   # `github-pages` gem (installed below). `texlive-full` is needed
-  # for building the formal specification.
+  # for building the formal specification. `python-pip` is needed
+  # to install the AWS CLI (installed below). `groff` is also
+  # needed for the AWS CLI.
   DEBIAN_FRONTEND=noninteractive apt-get -y install \
   build-essential \
   clang-4.0 \
   cmake>=3.7.1-1 \
   git \
+  groff \
   ninja-build \
+  python-pip \
   ruby2.3 \
   ruby2.3-dev \
   shellcheck \
@@ -34,6 +38,9 @@ RUN cd /root && \
 
   # Install the `github-pages` gem (for `make docs`).
   gem install github-pages -v 111 && \
+
+  # Install the AWS CLI (for `make spec`).
+  pip install awscli \
 
   # Build LLVM for Gram.
   cd gram && \


### PR DESCRIPTION
Add a post-build step to upload the spec to S3. The uploaded file is publicly accessible as [https://static.gram.org/gram.pdf](https://static.gram.org/gram.pdf).

/cc @ewang12

**Status:** Ready

**Fixes:** N/A
