### PR TITLE
Add git to release build dependencies

### DIFF
--- a/docker/Dockerfile-gram-deps
+++ b/docker/Dockerfile-gram-deps
@@ -23,6 +23,9 @@ RUN cd /root && \
     # For building LLVM
     cmake>=3.7.1-1 \
 
+    # For embedding the commit hash in the metadata reported by `gram -v`.
+    git \
+
     # Used by the AWS CLI (installed below)
     groff \
 


### PR DESCRIPTION
Add `git` to the release build dependencies. It used to be there, but I removed it in https://github.com/gramlang/gram/pull/74 because I thought it wasn't used. But now I remember: we use it to embed the commit hash in the version metadata so it can be reported by `gram -v`:

```bash
$ gram -v
Version: 0.0.1
Commit: cae87a99d2bf67dca56f04d8534b29554c368906
Build type: release
```

I added a comment this time so it won't be removed again.

/cc @ewang12

**Status:** Ready

**Fixes:** N/A
