### PR TITLE
Add the option to skip pushing gramlang/gram:deps in the deploy script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ script:
     docker run gramlang/gram -v && (
       test "$TRAVIS_PULL_REQUEST" != "false" ||
       test "$TRAVIS_BRANCH" != "master" ||
-      ./scripts/deploy.sh
+      SKIP_DOCKER_GRAM_DEPS_PUSH=YES ./scripts/deploy.sh
     )

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -5,14 +5,14 @@ set -eu -o pipefail
 # integration system. It does the following:
 # - Upload the spec (gram.pdf) to the `static.gram.org` S3 bucket
 # - Push the following Docker images:
-#   - gramlang/gram:deps
+#   - gramlang/gram:deps (optional, see SKIP_DOCKER_GRAM_DEPS_PUSH below)
 #   - gramlang/gram:build
 #   - gramlang/gram:latest
 #
 # Notes:
 # - This script assumes the Docker images have already been built via the
 #   appropriate make commands:
-#   - make docker-gram-deps
+#   - make docker-gram-deps (optional, see SKIP_DOCKER_GRAM_DEPS_PUSH below)
 #   - make docker-gram-build
 #   - make docker-gram
 # - Deploying the website (www.gram.org) happens automatically thanks to
@@ -24,6 +24,7 @@ set -eu -o pipefail
 #   AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY \
 #   DOCKER_USERNAME=gram \
 #   DOCKER_PASSWORD=KFHWNLDJGIAUEEXAMPLE \
+#   SKIP_DOCKER_GRAM_DEPS_PUSH=YES \
 #   ./deploy.sh
 
 # Upload the spec
@@ -37,6 +38,8 @@ docker run \
 
 # Upload the Docker images
 docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
-docker push gramlang/gram:deps
+if ! (echo "$SKIP_DOCKER_GRAM_DEPS_PUSH" | grep -qi '^YES$'); then
+  docker push gramlang/gram:deps
+fi
 docker push gramlang/gram:build
 docker push gramlang/gram:latest

--- a/scripts/get-compiler.sh
+++ b/scripts/get-compiler.sh
@@ -8,7 +8,7 @@ set -eu -o pipefail
 #   ./get-compiler.sh CC
 #   ./get-compiler.sh CXX
 
-if ! echo "$1" | grep -qi '^\(CC\|CXX\)$'; then
+if ! (echo "$1" | grep -qi '^\(CC\|CXX\)$'); then
   echo 'The argument must be CC or CXX.' >&2
   exit 1
 fi


### PR DESCRIPTION
Add the option to skip pushing the `gramlang/gram:deps` Docker image in the deploy script. In CI, we aren't building this image (we're just pulling it to save time), so it doesn't make sense to push it.

This is kind of inelegant, and I wish we had enough time in CI to build all the images.

/cc @ewang12

**Status:** Ready

**Fixes:** N/A
