### PR TITLE
Update the copyright year to 2017

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -2,7 +2,7 @@
 
 The Gram Project is distributed under a 3-clause BSD License.
 
-> Copyright (c) 2016, Stephan Boyer
+> Copyright (c) 2017, Stephan Boyer
 >
 > All rights reserved.
 >


### PR DESCRIPTION
Update the copyright year to 2017. Sometime soon we should figure out what to do about contributions from other people. My understanding (based on [this](http://producingoss.com/en/copyright-assignment.html)) is that we should have contributors sign a CLA or a copyright assignment. Let's make sure this happens before anyone else commits to the repo.

@ewang12 what do you think about the BSD license?

**Status:** Ready

**Fixes:** N/A
