### PR TITLE
Remove link hover animation

### DIFF
--- a/docs/css/main.scss
+++ b/docs/css/main.scss
@@ -16,13 +16,6 @@ $line-height: 24px;
   filter: progid:DXImageTransform.Microsoft.gradient(startStr='#{$start}', endStr='#{$end}');
 }
 
-@mixin transition($property, $duration) {
-  -o-transition: $property $duration;
-  -moz-transition: $property $duration;
-  -webkit-transition: $property $duration;
-  transition: $property $duration;
-}
-
 body {
   color: #333;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica,
@@ -49,8 +42,6 @@ a {
   }
 
   a {
-    @include transition(opacity, 0.2s);
-
     &:hover {
       opacity: 0.5;
       text-decoration: none;


### PR DESCRIPTION
The [website](https://www.gram.org/) has a subtle hover animation on the links in the header nav. I came across another website with similar animations, and it made the website feel sluggish to me. We can't be sluggish! Now the links will transition to/from their hover state instantaneously.

/cc @ewang12

**Status:** Ready

**Fixes:** N/A
