### PR TITLE
Change the deploy script to upload the spec PDF for non-branch builds

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,7 @@
 [Description of the change]
 
+If the formal specification was changed in this pull request, [here](https://static.gram.org/branch-MYBRANCH.pdf) is a link to the updated PDF.
+
 **Status:** Ready / In development
 
 **Fixes:** Link to issue (if applicable)

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,5 @@ script:
     make docker-gram &&
     docker run gramlang/gram -v && (
       test "$TRAVIS_PULL_REQUEST" != "false" ||
-      test "$TRAVIS_BRANCH" != "master" ||
       SKIP_DOCKER_GRAM_DEPS_PUSH=YES ./scripts/deploy.sh
     )

--- a/Makefile
+++ b/Makefile
@@ -137,10 +137,11 @@ spec: $(BUILD_PREFIX_COMMON)/spec/gram.pdf
 lint: $(BUILD_PREFIX)/llvm
 	# Make sure all lines conform to the line length limit.
 	scripts/check-line-lengths.sh \
-	  .github/* \
 	  .travis.yml \
-	  docker/* \
 	  Makefile \
+	  docker/* \
+	  driver/* \
+	  include/* \
 	  scripts/* \
 	  src/*
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [Gram](https://www.gram.org) is a high-level programming language with a small, extensible core and a strong, static type system.
 
+Unlike most programming language, Gram has a [formal specification](https://static.gram.org/gram.pdf).
+
 [![Build Status](https://travis-ci.org/gramlang/gram.svg?branch=master)](https://travis-ci.org/gramlang/gram)
 
 ## Installation

--- a/spec/gram.tex
+++ b/spec/gram.tex
@@ -47,6 +47,7 @@
 \newcommand\ccontext{\Gamma}
 \newcommand\cempty{\varnothing}
 \newcommand\cextend[3]{#1, \ \hastype{#2}{#3}}
+\newcommand\clookup[2]{#1\parens{#2}}
 
 % Operational semantics
 \newcommand\sstep[2]{#1 \longrightarrow #2}
@@ -108,7 +109,7 @@
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\hastype{\evar}{\ttype} \in \ccontext$}
+          \AxiomC{$\clookup{\ccontext}{\evar} = \ttype$}
         \RightLabel{(\textsc{T-Variable})}
         \UnaryInfC{$\tjudgment{\ccontext}{\evar}{\ttype}$}
       \end{prooftree}


### PR DESCRIPTION
Change the deploy script to upload the spec PDF for non-branch builds.

If the formal specification was changed in this pull request, [here](https://static.gram.org/branch-branch-spec.pdf) is a link to the updated PDF.

**Status:** Ready

**Fixes:** N/A
