### PR TITLE
Do not rebuild version.cpp unnecessarily

### DIFF
--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -46,9 +46,9 @@ int main(int argc, char *argv[]) {
   // Invoke the compiler.
   if (argc == 3 || argc == 4) {
     try {
-      auto output_type = gram::OutputType::AST;
       auto input_path = argv[1];
       auto output_path = argv[2];
+      auto output_type = gram::OutputType::AST;
       if (argc == 4) {
         if (std::string(argv[1]) == "--emit-tokens") {
           output_type = gram::OutputType::TOKENS;


### PR DESCRIPTION
Do not rebuild `version.cpp` unnecessarily.

If the formal specification was changed in this pull request, [here](https://static.gram.org/branch-version-cpp-force.pdf) is a link to the updated PDF.

**Status:** Ready

**Fixes:** N/A
