### PR TITLE
Upgrade to LLVM 5.0.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,11 +282,11 @@ $(BUILD_PREFIX)/dist/bin/gram: \
 	  $$( (uname -s | grep -qi 'Darwin') || echo '-static' )
 
 # This target builds LLVM, which is a dependency for Gram.
-$(BUILD_PREFIX)/llvm: deps/llvm-4.0.1.src.tar.xz
+$(BUILD_PREFIX)/llvm: deps/llvm-5.0.0.src.tar.xz
 	[ -n "$(CC)" -a -n "$(CXX)" ] # Ensure we have sufficient compilers.
 	rm -rf $(BUILD_PREFIX)/llvm
 	mkdir -p $(BUILD_PREFIX)/llvm/src
-	tar -xf deps/llvm-4.0.1.src.tar.xz -C $(BUILD_PREFIX)/llvm/src \
+	tar -xf deps/llvm-5.0.0.src.tar.xz -C $(BUILD_PREFIX)/llvm/src \
 	  --strip-components=1
 	mkdir -p $(BUILD_PREFIX)/llvm/build
 	cd $(BUILD_PREFIX)/llvm/build && cmake ../src \

--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -235,7 +235,7 @@ void gram::llc(
   llvm::initializeRewriteSymbolsLegacyPassPass(pass_registry);
   llvm::initializeWinEHPreparePass(pass_registry);
   llvm::initializeDwarfEHPreparePass(pass_registry);
-  llvm::initializeSafeStackPass(pass_registry);
+  llvm::initializeSafeStackLegacyPassPass(pass_registry);
   llvm::initializeSjLjEHPreparePass(pass_registry);
   llvm::initializePreISelIntrinsicLoweringLegacyPassPass(pass_registry);
   llvm::initializeGlobalMergePass(pass_registry);
@@ -302,18 +302,12 @@ void gram::llc(
   pass_manager_builder.OptLevel = 3;
   pass_manager_builder.SizeLevel = 1;
   pass_manager_builder.LibraryInfo = library_info;
-  pass_manager_builder.Inliner = llvm::createFunctionInliningPass(
-    pass_manager_builder.OptLevel,
-    pass_manager_builder.SizeLevel
-  );
   pass_manager_builder.DisableTailCalls = false;
   pass_manager_builder.DisableUnitAtATime = false;
   pass_manager_builder.DisableUnrollLoops = false;
-  pass_manager_builder.BBVectorize = true;
   pass_manager_builder.SLPVectorize = true;
   pass_manager_builder.LoopVectorize = true;
   pass_manager_builder.RerollLoops = false;
-  pass_manager_builder.LoadCombine = true;
   pass_manager_builder.NewGVN = false;
   pass_manager_builder.DisableGVNLoadPRE = false;
   pass_manager_builder.VerifyInput = false;
@@ -323,15 +317,6 @@ void gram::llc(
   pass_manager_builder.PrepareForThinLTO = false;
   pass_manager_builder.PerformThinLTO = false;
   pass_manager_builder.EnablePGOInstrGen = false;
-  pass_manager_builder.addExtension(
-    llvm::PassManagerBuilder::EP_EarlyAsPossible,
-    [&](
-      const llvm::PassManagerBuilder &,
-      llvm::legacy::PassManagerBase &pass_manager
-    ) {
-      target_machine->addEarlyAsPossiblePasses(pass_manager);
-    }
-  );
   pass_manager_builder.populateFunctionPassManager(function_pass_manager);
   pass_manager_builder.populateModulePassManager(pass_manager);
   pass_manager_builder.populateLTOPassManager(pass_manager);


### PR DESCRIPTION
Upgrade LLVM from 4.0.1 to 5.0.0. According to the release notes, the `BBVectorize` pass has been removed in favor of `SLPVectorize`, so it is safe to delete. I also had to delete a few other things to make the build pass, but couldn't find any mention of them in the release notes.

**Status:** Ready