### PR TITLE
Use the same visibility option as LLVM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -251,6 +251,7 @@ $(BUILD_PREFIX)/gram/obj/%.o: %.cpp $(HEADERS_DIST) $(BUILD_PREFIX)/llvm
 	  ) \
 	  -std=c++11 \
 	  -Wall -Wextra -Wpedantic -Werror -Wno-unused-parameter \
+	  -fvisibility-inlines-hidden \
 	  -o $@
 
 # This target builds the static library.


### PR DESCRIPTION
Use the same visibility option as LLVM.

After the LLVM 5.0 upgrade, I noticed the following warnings when building in debug mode (`make BUILD_TYPE=debug`):

```
ld: warning: direct access in function 'llvm::SystemZHazardRecognizer::dumpSU(llvm::SUnit*, llvm::raw_ostream&) const' from file 'build/debug/llvm/dist/lib/libLLVMSystemZCodeGen.a(SystemZHazardRecognizer.cpp.o)' to global weak symbol 'std::__1::char_traits<char>::eq(char, char)' from file 'build/debug/dist/lib/gram.a(compiler.o)' means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings.
ld: warning: direct access in function 'llvm::SystemZHazardRecognizer::dumpSU(llvm::SUnit*, llvm::raw_ostream&) const' from file 'build/debug/llvm/dist/lib/libLLVMSystemZCodeGen.a(SystemZHazardRecognizer.cpp.o)' to global weak symbol 'std::__1::char_traits<char>::eq(char, char)' from file 'build/debug/dist/lib/gram.a(compiler.o)' means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings.
ld: warning: direct access in function 'llvm::DOTGraphTraits<llvm::SelectionDAG*>::getNodeAttributes(llvm::SDNode const*, llvm::SelectionDAG const*)' from file 'build/debug/llvm/dist/lib/libLLVMSelectionDAG.a(SelectionDAGPrinter.cpp.o)' to global weak symbol 'std::__1::char_traits<char>::eq(char, char)' from file 'build/debug/dist/lib/gram.a(compiler.o)' means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings.
ld: warning: direct access in function 'llvm::CodeViewDebug::getFullFilepath(llvm::DIFile const*)' from file 'build/debug/llvm/dist/lib/libLLVMAsmPrinter.a(CodeViewDebug.cpp.o)' to global weak symbol 'std::__1::char_traits<char>::eq(char, char)' from file 'build/debug/dist/lib/gram.a(compiler.o)' means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings.
ld: warning: direct access in function 'llvm::CodeViewDebug::getFullFilepath(llvm::DIFile const*)' from file 'build/debug/llvm/dist/lib/libLLVMAsmPrinter.a(CodeViewDebug.cpp.o)' to global weak symbol 'std::__1::char_traits<char>::eq(char, char)' from file 'build/debug/dist/lib/gram.a(compiler.o)' means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings.
ld: warning: direct access in function 'llvm::CodeViewDebug::getFullFilepath(llvm::DIFile const*)' from file 'build/debug/llvm/dist/lib/libLLVMAsmPrinter.a(CodeViewDebug.cpp.o)' to global weak symbol 'std::__1::char_traits<char>::eq(char, char)' from file 'build/debug/dist/lib/gram.a(compiler.o)' means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings.
ld: warning: direct access in function '(anonymous namespace)::DataFlowSanitizer::addGlobalNamePrefix(llvm::GlobalValue*)' from file 'build/debug/llvm/dist/lib/libLLVMInstrumentation.a(DataFlowSanitizer.cpp.o)' to global weak symbol 'std::__1::char_traits<char>::eq(char, char)' from file 'build/debug/dist/lib/gram.a(compiler.o)' means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings.
ld: warning: direct access in function 'llvm::getPGOFuncNameVarName(llvm::StringRef, llvm::GlobalValue::LinkageTypes)' from file 'build/debug/llvm/dist/lib/libLLVMProfileData.a(InstrProf.cpp.o)' to global weak symbol 'std::__1::char_traits<char>::eq(char, char)' from file 'build/debug/dist/lib/gram.a(compiler.o)' means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings.
ld: warning: direct access in function 'llvm::getPGOFuncNameVarName(llvm::StringRef, llvm::GlobalValue::LinkageTypes)' from file 'build/debug/llvm/dist/lib/libLLVMProfileData.a(InstrProf.cpp.o)' to global weak symbol 'std::__1::char_traits<char>::eq(char, char)' from file 'build/debug/dist/lib/gram.a(compiler.o)' means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings.
ld: warning: direct access in function '(anonymous namespace)::hasObjCCategoryInModule(llvm::BitstreamCursor&)' from file 'build/debug/llvm/dist/lib/libLLVMBitReader.a(BitcodeReader.cpp.o)' to global weak symbol 'std::__1::char_traits<char>::eq(char, char)' from file 'build/debug/dist/lib/gram.a(compiler.o)' means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings.
ld: warning: direct access in function '(anonymous namespace)::hasObjCCategoryInModule(llvm::BitstreamCursor&)' from file 'build/debug/llvm/dist/lib/libLLVMBitReader.a(BitcodeReader.cpp.o)' to global weak symbol 'std::__1::char_traits<char>::eq(char, char)' from file 'build/debug/dist/lib/gram.a(compiler.o)' means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings.
ld: warning: direct access in function 'updateTripleOSVersion(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >)' from file 'build/debug/llvm/dist/lib/libLLVMSupport.a(Host.cpp.o)' to global weak symbol 'std::__1::char_traits<char>::eq(char, char)' from file 'build/debug/dist/lib/gram.a(compiler.o)' means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings.
ld: warning: direct access in function 'updateTripleOSVersion(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >)' from file 'build/debug/llvm/dist/lib/libLLVMSupport.a(Host.cpp.o)' to global weak symbol 'std::__1::char_traits<char>::eq(char, char)' from file 'build/debug/dist/lib/gram.a(compiler.o)' means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings.
```

I admit to not fully understanding what the warning is about. But at least it gave me a hint:

> This was likely caused by different translation units being compiled with different visibility settings.

I looked at how LLVM is invoking the compiler by looking in `build/debug/llvm/build/compile_commands.json`. It turns out, LLVM uses the `-fvisibility-inlines-hidden` flag when compiling its sources. So I added that flag to our `Makefile` and the warnings went away.

**Status:** Ready

**Fixes:** N/A