### PR TITLE
Make the error constructors return a `Result` when appropriate

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -32,24 +32,11 @@ impl error::Error for Error {
 }
 
 // This function constructs an `Error` from a message.
-pub fn throw<S: Into<String>>(message: S) -> Error {
-    Error {
+pub fn throw<S: Into<String>>(message: S) -> Result<(), Error> {
+    Err(Error {
         message: message.into(),
         reason: None,
-    }
-}
-
-// This function constructs an `Error` from a message and a reason. It's written in a curried style
-// so it can be used in a higher-order fashion, e.g.,
-// `foo.map_err(throw_reason("Error doing foo."))`.
-pub fn throw_reason<S: Into<String>, E: error::Error + 'static>(
-    message: S,
-) -> impl FnOnce(E) -> Error {
-    let message = message.into();
-    move |error: E| Error {
-        message,
-        reason: Some(Box::new(error)),
-    }
+    })
 }
 
 // This function constructs an `Error` that occurs at a specific location in a source file.
@@ -58,114 +45,127 @@ pub fn throw_context<S: Borrow<str>, T: Borrow<Path>, U: Borrow<str>>(
     source_name: Option<T>,
     source_contents: U,
     source_range: (usize, usize), // [start, end)
-) -> Error {
-    // Check if the source range is empty.
-    if source_range.0 == source_range.1 {
-        // There's no source to render.
-        Error {
-            message: if let Some(path) = source_name {
-                format!(
-                    "Error in {}: {}",
-                    path.borrow().to_string_lossy().code_str(),
-                    message.borrow()
-                )
-            } else {
-                format!("Error: {}", message.borrow())
-            },
-            reason: None,
-        }
-    } else {
-        // We have a source range. Use it to show the relevant lines.
-        let mut lines = vec![];
-        let mut pos = 0_usize;
+) -> Result<(), Error> {
+    Err(
+        // Check if the source range is empty.
+        if source_range.0 == source_range.1 {
+            // There's no source to render.
+            Error {
+                message: if let Some(path) = source_name {
+                    format!(
+                        "Error in {}: {}",
+                        path.borrow().to_string_lossy().code_str(),
+                        message.borrow()
+                    )
+                } else {
+                    format!("Error: {}", message.borrow())
+                },
+                reason: None,
+            }
+        } else {
+            // We have a source range. Use it to show the relevant lines.
+            let mut lines = vec![];
+            let mut pos = 0_usize;
 
-        // Find the relevant lines.
-        for (i, line) in source_contents.borrow().split('\n').enumerate() {
-            // Record the start of the line before we advance the cursor.
-            let line_start = pos;
+            // Find the relevant lines.
+            for (i, line) in source_contents.borrow().split('\n').enumerate() {
+                // Record the start of the line before we advance the cursor.
+                let line_start = pos;
 
-            // Move the cursor to the start of the next line.
-            pos += line.len() + 1;
+                // Move the cursor to the start of the next line.
+                pos += line.len() + 1;
 
-            // If the start of the line is past the end of the range, we're done.
-            if line_start >= source_range.1 {
-                break;
+                // If the start of the line is past the end of the range, we're done.
+                if line_start >= source_range.1 {
+                    break;
+                }
+
+                // If the end of this line is before the start of the range, we haven't reached the
+                // lines of interest yet.
+                if pos <= source_range.0 {
+                    continue;
+                }
+
+                // Highlight the relevant part of the line.
+                let trimmed_line = line.trim_end();
+                let (section_start, section_end) = if source_range.0 > line_start {
+                    (
+                        min(source_range.0 - line_start, trimmed_line.len()),
+                        min(source_range.1 - line_start, trimmed_line.len()),
+                    )
+                } else {
+                    (0, min(source_range.1 - line_start, trimmed_line.len()))
+                };
+                let colored_line = format!(
+                    "{}{}{}",
+                    &trimmed_line[..section_start],
+                    &trimmed_line[section_start..section_end].red(),
+                    &trimmed_line[section_end..]
+                );
+
+                // Record the line number and the line contents. We trim the end of the line to
+                // remove any carriage return that might have been present before the line feed (as
+                // well as any other whitespace).
+                lines.push(((i + 1).to_string(), colored_line));
             }
 
-            // If the end of this line is before the start of the range, we haven't reached the lines
-            // of interest yet.
-            if pos <= source_range.0 {
-                continue;
+            // Compute the width of the string representation of the largest relevant line number.
+            let gutter_width = lines
+                .iter()
+                .fold(0_usize, |acc, (line_number, _)| max(acc, line_number.len()));
+
+            // Render the code listing with line numbers.
+            let listing = lines
+                .iter()
+                .map(|(line_number, line)| {
+                    format!(
+                        "{} | {}",
+                        line_number.pad(gutter_width, ' ', Alignment::Right, false),
+                        line
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+
+            // Now we have everything we need to construct the error.
+            Error {
+                message: if let Some(path) = source_name {
+                    format!(
+                        "Error in {}: {}\n\n{}",
+                        path.borrow().to_string_lossy().code_str(),
+                        message.borrow(),
+                        listing
+                    )
+                } else {
+                    format!("Error: {}\n\n{}", message.borrow(), listing)
+                },
+                reason: None,
             }
+        },
+    )
+}
 
-            // Highlight the relevant part of the line.
-            let trimmed_line = line.trim_end();
-            let (section_start, section_end) = if source_range.0 > line_start {
-                (
-                    min(source_range.0 - line_start, trimmed_line.len()),
-                    min(source_range.1 - line_start, trimmed_line.len()),
-                )
-            } else {
-                (0, min(source_range.1 - line_start, trimmed_line.len()))
-            };
-            let colored_line = format!(
-                "{}{}{}",
-                &trimmed_line[..section_start],
-                &trimmed_line[section_start..section_end].red(),
-                &trimmed_line[section_end..]
-            );
-
-            // Record the line number and the line contents. We trim the end of the line to remove
-            // any carriage return that might have been present before the line feed (as well as any
-            // other whitespace).
-            lines.push(((i + 1).to_string(), colored_line));
-        }
-
-        // Compute the width of the string representation of the largest relevant line number.
-        let gutter_width = lines
-            .iter()
-            .fold(0_usize, |acc, (line_number, _)| max(acc, line_number.len()));
-
-        // Render the code listing with line numbers.
-        let listing = lines
-            .iter()
-            .map(|(line_number, line)| {
-                format!(
-                    "{} | {}",
-                    line_number.pad(gutter_width, ' ', Alignment::Right, false),
-                    line
-                )
-            })
-            .collect::<Vec<_>>()
-            .join("\n");
-
-        // Now we have everything we need to construct the error.
-        Error {
-            message: if let Some(path) = source_name {
-                format!(
-                    "Error in {}: {}\n\n{}",
-                    path.borrow().to_string_lossy().code_str(),
-                    message.borrow(),
-                    listing
-                )
-            } else {
-                format!("Error: {}\n\n{}", message.borrow(), listing)
-            },
-            reason: None,
-        }
+// This function constructs an `Error` from a message and a reason. It's written in a curried style
+// so it can be used in a higher-order fashion, e.g.,
+// `foo.map_err(lift("Error doing foo."))`.
+pub fn lift<S: Into<String>, E: error::Error + 'static>(message: S) -> impl FnOnce(E) -> Error {
+    let message = message.into();
+    move |error: E| Error {
+        message,
+        reason: Some(Box::new(error)),
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::error::{throw, throw_context, throw_reason, Error};
+    use crate::error::{lift, throw, throw_context, Error};
     use std::path::{Path, PathBuf};
 
     #[test]
     fn throw_simple() {
         colored::control::set_override(false);
 
-        let error = throw("An error occurred.");
+        let error = throw("An error occurred.").unwrap_err();
 
         assert_eq!(error.message, "An error occurred.".to_owned());
 
@@ -173,24 +173,11 @@ mod tests {
     }
 
     #[test]
-    fn throw_reason_simple() {
-        colored::control::set_override(false);
-
-        let error = throw_reason("An error occurred.")(Error {
-            message: "This is why.".to_owned(),
-            reason: None,
-        });
-
-        assert_eq!(error.message, "An error occurred.".to_owned());
-
-        assert_eq!(error.reason.unwrap().to_string(), "This is why.".to_owned());
-    }
-
-    #[test]
     fn throw_context_no_path_empty_range() {
         colored::control::set_override(false);
 
-        let error = throw_context::<&str, &Path, &str>("An error occurred.", None, "", (0, 0));
+        let error =
+            throw_context::<&str, &Path, &str>("An error occurred.", None, "", (0, 0)).unwrap_err();
 
         assert_eq!(error.message, "Error: An error occurred.".to_owned());
     }
@@ -204,7 +191,8 @@ mod tests {
             Some(PathBuf::from("foo.g")),
             "",
             (0, 0),
-        );
+        )
+        .unwrap_err();
 
         assert_eq!(
             error.message,
@@ -216,7 +204,8 @@ mod tests {
     fn throw_context_no_path_single_line_full_range() {
         colored::control::set_override(false);
 
-        let error = throw_context::<&str, &Path, &str>("An error occurred.", None, "foo", (0, 3));
+        let error = throw_context::<&str, &Path, &str>("An error occurred.", None, "foo", (0, 3))
+            .unwrap_err();
 
         assert_eq!(
             error.message,
@@ -233,7 +222,8 @@ mod tests {
             Some(PathBuf::from("foo.g")),
             "foo",
             (0, 3),
-        );
+        )
+        .unwrap_err();
 
         assert_eq!(
             error.message,
@@ -250,7 +240,8 @@ mod tests {
             None,
             "foo\nbar\nbaz",
             (0, 11),
-        );
+        )
+        .unwrap_err();
 
         assert_eq!(
             error.message,
@@ -267,7 +258,8 @@ mod tests {
             None,
             "foo\nbar\nbaz\nqux",
             (5, 11),
-        );
+        )
+        .unwrap_err();
 
         assert_eq!(
             error.message,
@@ -284,11 +276,26 @@ mod tests {
             None,
             "foo\nbar\nbaz\nqux\nfoo\nbar\nbaz\nqux\nfoo\nbar\nbaz\nqux",
             (33, 42),
-        );
+        )
+        .unwrap_err();
 
         assert_eq!(
             error.message,
             "Error: An error occurred.\n\n 9 | foo\n10 | bar\n11 | baz".to_owned()
         );
+    }
+
+    #[test]
+    fn lift_simple() {
+        colored::control::set_override(false);
+
+        let error = lift("An error occurred.")(Error {
+            message: "This is why.".to_owned(),
+            reason: None,
+        });
+
+        assert_eq!(error.message, "An error occurred.".to_owned());
+
+        assert_eq!(error.reason.unwrap().to_string(), "This is why.".to_owned());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ mod token;
 mod tokenizer;
 
 use crate::{
-    error::{throw, throw_reason, Error},
+    error::{lift, throw, Error},
     format::CodeStr,
     tokenizer::tokenize,
 };
@@ -89,10 +89,10 @@ fn shell_completion<S: Borrow<str>>(shell: S) -> Result<(), Error> {
         "powershell" => Shell::PowerShell,
         "elvish" => Shell::Elvish,
         _ => {
-            return Err(throw(format!(
+            return throw(format!(
                 "Unknown shell {}. Must be one of Bash, Fish, Zsh, PowerShell, or Elvish.",
                 shell.borrow().code_str()
-            )))
+            ))
         }
     };
 
@@ -124,7 +124,7 @@ fn entry() -> Result<(), Error> {
                     .unwrap_or("main.g"),
             );
 
-            let source = read_to_string(&source_path).map_err(throw_reason(format!(
+            let source = read_to_string(&source_path).map_err(lift(format!(
                 "Error when reading file {}.",
                 source_path.to_string_lossy().code_str(),
             )))?;

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -51,7 +51,7 @@ pub fn tokenize<'a>(
                         variant: Variant::ThickArrow,
                     });
                 } else {
-                    return Err(throw_context(
+                    throw_context(
                         format!(
                             "Unexpected symbol {}.",
                             &source_contents[i..i + c.len_utf8()].code_str()
@@ -59,7 +59,7 @@ pub fn tokenize<'a>(
                         source_name,
                         source_contents,
                         (i, i + c.len_utf8()),
-                    ));
+                    )?;
                 }
             }
             '-' => {
@@ -70,7 +70,7 @@ pub fn tokenize<'a>(
                         variant: Variant::ThinArrow,
                     });
                 } else {
-                    return Err(throw_context(
+                    throw_context(
                         format!(
                             "Unexpected symbol {}.",
                             &source_contents[i..i + c.len_utf8()].code_str()
@@ -78,7 +78,7 @@ pub fn tokenize<'a>(
                         source_name,
                         source_contents,
                         (i, i + c.len_utf8()),
-                    ));
+                    )?;
                 }
             }
 
@@ -107,7 +107,7 @@ pub fn tokenize<'a>(
 
             // If we made it this far, the input contains something unexpected.
             _ => {
-                return Err(throw_context(
+                throw_context(
                     format!(
                         "Unexpected symbol {}.",
                         &source_contents[i..i + c.len_utf8()].code_str()
@@ -115,7 +115,7 @@ pub fn tokenize<'a>(
                     source_name,
                     source_contents,
                     (i, i + c.len_utf8()),
-                ))
+                )?;
             }
         }
     }


### PR DESCRIPTION
Make the error constructors return a `Result` when appropriate. This makes common patterns less verbose.