### PR TITLE
Ensure every top-level definition has a comment

### DIFF
--- a/examples/tokens.g
+++ b/examples/tokens.g
@@ -1,1 +1,3 @@
-(a : type) => (b : type) => (f : (_ : a) -> b) => (x : a) => f x
+(a : type) => (b : type) =>
+  (f : (_ : a) -> b) => (x : a) =>
+    f x

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,15 +1,25 @@
 use std::rc::Rc;
 
+// The token stream is parsed into an abstract syntax tree (AST). This struct represents a node in
+// an AST.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Node<'a> {
     pub source_range: (usize, usize), // [start, end)
     pub variant: Variant<'a>,
 }
 
+// We assign each node a "variant" describing what kind of node it is.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Variant<'a> {
+    // A lambda, or dependent function, is a computable function.
     Lambda(&'a str, Rc<Node<'a>>, Rc<Node<'a>>),
+
+    // Pi types, or dependent function types, are the types ascribed to lambdas.
     Pi(&'a str, Rc<Node<'a>>, Rc<Node<'a>>),
+
+    // A variable is a placeholder bound by a lambda or a pi type.
     Variable(&'a str),
+
+    // An application is the act of applying a lambda to an argument.
     Application(Rc<Node<'a>>, Rc<Node<'a>>),
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,11 +1,14 @@
 use std::fmt::{Display, Formatter, Result};
 
+// The first step of compilation is to split the source into a stream of tokens. This struct
+// represents a single token.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Token<'a> {
     pub source_range: (usize, usize), // [start, end)
     pub variant: Variant<'a>,
 }
 
+// We assign each token a "variant" describing what kind of token it is.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Variant<'a> {
     Colon,


### PR DESCRIPTION
Ensure every top-level definition has a comment.