### PR TITLE
Implement the features necessary to support shebangs

### DIFF
--- a/examples/identity.g
+++ b/examples/identity.g
@@ -1,3 +1,4 @@
+#!/usr/bin/env gram
 (a : type) => (b : type) =>
   (f : (_ : a) -> b) => (x : a) =>
     f x

--- a/src/error.rs
+++ b/src/error.rs
@@ -176,7 +176,7 @@ pub fn lift<T: Into<String>, U: error::Error + 'static>(message: T) -> impl FnOn
 #[cfg(test)]
 mod tests {
     use crate::error::{lift, throw, throw_context, Error};
-    use std::path::{Path, PathBuf};
+    use std::path::Path;
 
     #[test]
     fn throw_no_source() {
@@ -193,8 +193,7 @@ mod tests {
     fn throw_source() {
         colored::control::set_override(false);
 
-        let error =
-            throw::<_, _, ()>("An error occurred.", Some(PathBuf::from("foo.g"))).unwrap_err();
+        let error = throw::<_, _, ()>("An error occurred.", Some(Path::new("foo.g"))).unwrap_err();
 
         assert_eq!(
             error.message,
@@ -220,7 +219,7 @@ mod tests {
 
         let error = throw_context::<_, _, _, ()>(
             "An error occurred.",
-            Some(PathBuf::from("foo.g")),
+            Some(Path::new("foo.g")),
             "",
             (0, 0),
         )
@@ -252,7 +251,7 @@ mod tests {
 
         let error = throw_context::<_, _, _, ()>(
             "An error occurred.",
-            Some(PathBuf::from("foo.g")),
+            Some(Path::new("foo.g")),
             "foo",
             (0, 3),
         )

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -105,6 +105,15 @@ pub fn tokenize<'a>(
             // Skip whitespace.
             _ if c.is_whitespace() => continue,
 
+            // Skip comments.
+            '#' => {
+                for (_, d) in &mut iter {
+                    if d == '\n' {
+                        break;
+                    }
+                }
+            }
+
             // If we made it this far, the input contains something unexpected.
             _ => {
                 throw_context(

--- a/toast.yml
+++ b/toast.yml
@@ -106,7 +106,7 @@ tasks:
     command: |
       set -euo pipefail
       . $HOME/.cargo/env
-      cargo run -- run examples/tokens.g
+      cargo run -- examples/identity.g
 
   check:
     dependencies:


### PR DESCRIPTION
Implement the features necessary to support shebangs:

- Comments that start with `#` and continue to the end of the line
- Running a program with no subcommand (`gram foo.g`)

This PR also removes a few unnecessary `pub` modifiers and replaces `PathBuf::from` with `Path::new`.