### PR TITLE
Compute De Bruijn indices for variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,7 @@ dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pad 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -83,6 +84,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "strsim"
@@ -157,6 +163,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)" = "1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8"
 "checksum pad 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "d2ad9b889f1b12e0b9ee24db044b5129150d5eada288edc800f789928dc8c0e3"
+"checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9e5b9a66db815dcfd2da92db471106457082577c3c278d4138ab3e3b4e189327"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ readme = "README.md"
 atty = "0.2"
 colored = "1"
 pad = "0.1"
+scopeguard = "1.0"
 
 [dependencies.clap]
 version = "2"

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -17,8 +17,9 @@ pub enum Variant<'a> {
     // Pi types, or dependent function types, are the types ascribed to lambdas.
     Pi(&'a str, Rc<Node<'a>>, Rc<Node<'a>>),
 
-    // A variable is a placeholder bound by a lambda or a pi type.
-    Variable(&'a str),
+    // A variable is a placeholder bound by a lambda or a pi type. The integer is the De Bruijn
+    // index for the variable.
+    Variable(&'a str, usize),
 
     // An application is the act of applying a lambda to an argument.
     Application(Rc<Node<'a>>, Rc<Node<'a>>),

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,9 @@ use clap::{
     AppSettings::{ColoredHelp, UnifiedHelpMessage, VersionlessSubcommands},
     Arg, Shell, SubCommand,
 };
-use std::{borrow::Borrow, fs::read_to_string, io::stdout, path::Path, process::exit};
+use std::{
+    borrow::Borrow, collections::HashMap, fs::read_to_string, io::stdout, path::Path, process::exit,
+};
 
 // The program version
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -100,8 +102,17 @@ fn run<T: Borrow<Path>>(source_path: T) -> Result<(), Error> {
     // Tokenize the source file.
     let tokens = tokenize(Some(source_path.borrow()), &source_contents)?;
 
+    // Construct a hash table to represent the variables in scope.
+    let mut context = HashMap::<&str, usize>::new();
+    context.insert("type", 0);
+
     // Parse the source file.
-    let node = parse(Some(source_path.borrow()), &source_contents, &tokens)?;
+    let node = parse(
+        Some(source_path.borrow()),
+        &source_contents,
+        &tokens,
+        &mut context,
+    )?;
 
     // For now, just print the AST.
     println!("{:?}", node);


### PR DESCRIPTION
Compute De Bruijn indices for variables. The parser will now report an error upon encountering an undefined variable.