### PR TITLE
Make the parser set the `group` field as expected

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -31,7 +31,17 @@ pub enum Variant<'a> {
 
 impl<'a> Display for Node<'a> {
     fn fmt(&self, f: &mut Formatter) -> Result {
-        write!(f, "{}", self.variant)
+        if self.group {
+            write!(f, "(")?;
+        }
+
+        write!(f, "{}", self.variant)?;
+
+        if self.group {
+            write!(f, ")")?;
+        }
+
+        Ok(())
     }
 }
 
@@ -40,12 +50,12 @@ impl<'a> Display for Variant<'a> {
         match self {
             Self::Variable(variable, _) => write!(f, "{}", variable),
             Self::Lambda(variable, domain, body) => {
-                write!(f, "({} : {}) => ({})", variable, domain, body)
+                write!(f, "({} : {}) => {}", variable, domain, body)
             }
             Self::Pi(variable, domain, codomain) => {
-                write!(f, "({} : {}) -> ({})", variable, domain, codomain)
+                write!(f, "({} : {}) -> {}", variable, domain, codomain)
             }
-            Self::Application(applicand, argument) => write!(f, "({}) ({})", applicand, argument),
+            Self::Application(applicand, argument) => write!(f, "{} {}", applicand, argument),
         }
     }
 }

--- a/src/de_bruijn.rs
+++ b/src/de_bruijn.rs
@@ -74,12 +74,18 @@ pub fn open<'a, T: Borrow<Node<'a>>, U: Borrow<Node<'a>>>(
             } else if *index < index_to_replace {
                 Rc::new(node_to_open.clone())
             } else {
-                shift(node_to_insert, 0, index_to_replace)
+                let shifted_node = shift(node_to_insert, 0, index_to_replace);
+
+                Rc::new(Node {
+                    source_range: shifted_node.source_range,
+                    group: true, // To ensure the resulting node is still parse-able when printed
+                    variant: shifted_node.variant.clone(),
+                })
             }
         }
         Lambda(variable, domain, body) => Rc::new(Node {
             source_range: node_to_open.source_range,
-            group: node_to_open.group,
+            group: true, // To ensure the resulting node is still parse-able when printed
             variant: Lambda(
                 variable,
                 open(&**domain, index_to_replace, node_to_insert),
@@ -88,7 +94,7 @@ pub fn open<'a, T: Borrow<Node<'a>>, U: Borrow<Node<'a>>>(
         }),
         Pi(variable, domain, codomain) => Rc::new(Node {
             source_range: node_to_open.source_range,
-            group: node_to_open.group,
+            group: true, // To ensure the resulting node is still parse-able when printed
             variant: Pi(
                 variable,
                 open(&**domain, index_to_replace, node_to_insert),
@@ -97,7 +103,7 @@ pub fn open<'a, T: Borrow<Node<'a>>, U: Borrow<Node<'a>>>(
         }),
         Application(applicand, argument) => Rc::new(Node {
             source_range: node_to_open.source_range,
-            group: node_to_open.group,
+            group: true, // To ensure the resulting node is still parse-able when printed
             variant: Application(
                 open(&**applicand, index_to_replace, node_to_insert),
                 open(&**argument, index_to_replace, node_to_insert),
@@ -305,7 +311,7 @@ mod tests {
             ),
             Node {
                 source_range: Some((3, 4)),
-                group: false,
+                group: true,
                 variant: Variable("y", 0),
             },
         );
@@ -389,17 +395,17 @@ mod tests {
             ),
             Node {
                 source_range: Some((97, 112)),
-                group: false,
+                group: true,
                 variant: Lambda(
                     "a",
                     Rc::new(Node {
                         source_range: Some((3, 4)),
-                        group: false,
+                        group: true,
                         variant: Variable("x", 4),
                     }),
                     Rc::new(Node {
                         source_range: Some((3, 4)),
-                        group: false,
+                        group: true,
                         variant: Variable("x", 5),
                     }),
                 ),
@@ -437,17 +443,17 @@ mod tests {
             ),
             Node {
                 source_range: Some((97, 112)),
-                group: false,
+                group: true,
                 variant: Pi(
                     "a",
                     Rc::new(Node {
                         source_range: Some((3, 4)),
-                        group: false,
+                        group: true,
                         variant: Variable("x", 4),
                     }),
                     Rc::new(Node {
                         source_range: Some((3, 4)),
-                        group: false,
+                        group: true,
                         variant: Variable("x", 5),
                     }),
                 ),
@@ -484,11 +490,11 @@ mod tests {
             ),
             Node {
                 source_range: Some((97, 112)),
-                group: false,
+                group: true,
                 variant: Application(
                     Rc::new(Node {
                         source_range: Some((3, 4)),
-                        group: false,
+                        group: true,
                         variant: Variable("x", 4),
                     }),
                     Rc::new(Node {

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,11 +132,8 @@ fn run<T: Borrow<Path>>(source_path: T) -> Result<(), Error> {
         variant: ast::Variant::Variable(TYPE, 0), // [tag:context-starts-with-type]
     })];
 
-    // Normalize the term.
-    let normal_form = normalize(&node);
-
     // Print the normal form.
-    println!("# Normal form:\n\n{}\n", normal_form);
+    println!("# Normal form:\n\n{}\n", normalize(&node));
 
     // Type check the AST.
     let node_type = type_check(
@@ -146,8 +143,8 @@ fn run<T: Borrow<Path>>(source_path: T) -> Result<(), Error> {
         &mut type_checking_context,
     )?;
 
-    // Print the type.
-    println!("# Type:\n\n{}", node_type);
+    // Normalize and print the type.
+    println!("# Type:\n\n{}", normalize(node_type));
 
     // If we made it this far, nothing went wrong.
     Ok(())

--- a/src/normalizer.rs
+++ b/src/normalizer.rs
@@ -22,7 +22,7 @@ pub fn normalize<'a, T: Borrow<Node<'a>>>(node: T) -> Rc<Node<'a>> {
             // For lambdas, we simply reduce the domain and body.
             Rc::new(Node {
                 source_range: node.source_range,
-                group: node.group,
+                group: true, // To ensure the resulting node is still parse-able when printed
                 variant: Lambda(variable, normalize(&**domain), normalize(&**body)),
             })
         }
@@ -30,7 +30,7 @@ pub fn normalize<'a, T: Borrow<Node<'a>>>(node: T) -> Rc<Node<'a>> {
             // For pi types, we simply reduce the domain and codomain.
             Rc::new(Node {
                 source_range: node.source_range,
-                group: node.group,
+                group: true, // To ensure the resulting node is still parse-able when printed
                 variant: Pi(variable, normalize(&**domain), normalize(&**codomain)),
             })
         }
@@ -49,7 +49,7 @@ pub fn normalize<'a, T: Borrow<Node<'a>>>(node: T) -> Rc<Node<'a>> {
                 // We didn't get a lambda. Just reduce the argument.
                 Rc::new(Node {
                     source_range: node.source_range,
-                    group: node.group,
+                    group: true, // To ensure the resulting node is still parse-able when printed
                     variant: Application(normalized_applicand, normalized_argument),
                 })
             }
@@ -107,17 +107,17 @@ mod tests {
             *normalize(node),
             Node {
                 source_range: Some((0, 48)),
-                group: false,
+                group: true,
                 variant: Lambda(
                     "x",
                     Rc::new(Node {
                         source_range: Some((23, 24)),
-                        group: false,
+                        group: true,
                         variant: Variable("p", 1),
                     }),
                     Rc::new(Node {
                         source_range: Some((47, 48)),
-                        group: false,
+                        group: true,
                         variant: Variable("q", 1),
                     }),
                 ),
@@ -141,17 +141,17 @@ mod tests {
             *normalize(node),
             Node {
                 source_range: Some((0, 48)),
-                group: false,
+                group: true,
                 variant: Pi(
                     "x",
                     Rc::new(Node {
                         source_range: Some((23, 24)),
-                        group: false,
+                        group: true,
                         variant: Variable("p", 1),
                     }),
                     Rc::new(Node {
                         source_range: Some((47, 48)),
-                        group: false,
+                        group: true,
                         variant: Variable("q", 1),
                     }),
                 ),
@@ -175,16 +175,16 @@ mod tests {
             *normalize(node),
             Node {
                 source_range: Some((2, 42)),
-                group: false,
+                group: true,
                 variant: Application(
                     Rc::new(Node {
                         source_range: Some((19, 20)),
-                        group: false,
+                        group: true,
                         variant: Variable("y", 1),
                     }),
                     Rc::new(Node {
                         source_range: Some((41, 42)),
-                        group: false,
+                        group: true,
                         variant: Variable("w", 0),
                     }),
                 ),
@@ -207,7 +207,7 @@ mod tests {
             *normalize(node),
             Node {
                 source_range: Some((18, 19)),
-                group: false,
+                group: true,
                 variant: Variable("y", 0),
             },
         );

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -402,7 +402,7 @@ fn reassociate_applications<'a>(acc: Option<Rc<Node<'a>>>, node: Rc<Node<'a>>) -
                         } else {
                             None
                         },
-                        group: node.group,
+                        group: true, // To ensure the resulting node is still parse-able when printed
                         variant: ast::Variant::Application(
                             reassociate_applications(Some(acc), applicand.clone()),
                             reassociate_applications(None, argument.clone()),
@@ -429,7 +429,7 @@ fn reassociate_applications<'a>(acc: Option<Rc<Node<'a>>>, node: Rc<Node<'a>>) -
                             } else {
                                 None
                             },
-                            group: node.group,
+                            group: true, // To ensure the resulting node is still parse-able when printed
                             variant: ast::Variant::Application(acc, applicand.clone()),
                         })
                     } else {
@@ -441,9 +441,8 @@ fn reassociate_applications<'a>(acc: Option<Rc<Node<'a>>>, node: Rc<Node<'a>>) -
         }
     };
 
-    // We end up here as long as `node` isn't an application with a non-grouped argument. If we
-    // have an accumulator, construct an application as described above. Otherwise, just return the
-    // reduced node.
+    // We end up here as long as `node` isn't an application. If we have an accumulator, construct
+    // an application as described above. Otherwise, just return the reduced node.
     if let Some(acc) = acc {
         Rc::new(Node {
             source_range: if let (Some((start, _)), Some((_, end))) =
@@ -453,7 +452,7 @@ fn reassociate_applications<'a>(acc: Option<Rc<Node<'a>>>, node: Rc<Node<'a>>) -
             } else {
                 None
             },
-            group: false,
+            group: true, // To ensure the resulting node is still parse-able when printed
             variant: ast::Variant::Application(acc, reduced),
         })
     } else {
@@ -1024,7 +1023,7 @@ mod tests {
             parse(None, source, &tokens[..], &mut context).unwrap(),
             Node {
                 source_range: Some((0, 3)),
-                group: false,
+                group: true,
                 variant: Application(
                     Rc::new(Node {
                         source_range: Some((0, 1)),
@@ -1054,11 +1053,11 @@ mod tests {
             parse(None, source, &tokens[..], &mut context).unwrap(),
             Node {
                 source_range: Some((0, 5)),
-                group: false,
+                group: true,
                 variant: Application(
                     Rc::new(Node {
                         source_range: Some((0, 3)),
-                        group: false,
+                        group: true,
                         variant: Application(
                             Rc::new(Node {
                                 source_range: Some((0, 1)),
@@ -1104,7 +1103,7 @@ mod tests {
                     }),
                     Rc::new(Node {
                         source_range: Some((3, 6)),
-                        group: false,
+                        group: true,
                         variant: Application(
                             Rc::new(Node {
                                 source_range: Some((3, 4)),
@@ -1203,7 +1202,7 @@ mod tests {
                                             }),
                                             Rc::new(Node {
                                                 source_range: Some((61, 64)),
-                                                group: false,
+                                                group: true,
                                                 variant: Application(
                                                     Rc::new(Node {
                                                         source_range: Some((61, 62)),


### PR DESCRIPTION
Make the parser set the `group` field as expected, or at least a conservative approximation of it. The invariant is that printing a node and parsing the result should be syntactically equal (as defined by the `equality::syntactically_equal` function) the original node.