### PR TITLE
Simplify the structure of parsing and type checking contexts by implicitly assuming `TYPE` is at the front

### DIFF
--- a/src/equality.rs
+++ b/src/equality.rs
@@ -53,288 +53,225 @@ mod tests {
         equality::{definitionally_equal, syntactically_equal},
         parser::parse,
         tokenizer::tokenize,
-        type_checker::TYPE,
     };
-    use std::collections::HashMap;
 
     #[test]
     fn syntactically_equal_alpha() {
-        let mut context1 = HashMap::<&str, usize>::new();
-        context1.insert("x", 0);
-
+        let context1 = ["x"];
         let source1 = "x";
 
         let tokens1 = tokenize(None, source1).unwrap();
-        let node1 = parse(None, source1, &tokens1[..], &mut context1).unwrap();
+        let node1 = parse(None, source1, &tokens1[..], context1).unwrap();
 
-        let mut context2 = HashMap::<&str, usize>::new();
-        context2.insert("y", 0);
-
+        let context2 = ["y"];
         let source2 = "y";
 
         let tokens2 = tokenize(None, source2).unwrap();
-        let node2 = parse(None, source2, &tokens2[..], &mut context2).unwrap();
+        let node2 = parse(None, source2, &tokens2[..], context2).unwrap();
 
         assert_eq!(syntactically_equal(node1, node2), true);
     }
 
     #[test]
     fn syntactically_inequal_variable() {
-        let mut context1 = HashMap::<&str, usize>::new();
-        context1.insert("x", 0);
-
+        let context1 = ["x"];
         let source1 = "x";
 
         let tokens1 = tokenize(None, source1).unwrap();
-        let node1 = parse(None, source1, &tokens1[..], &mut context1).unwrap();
+        let node1 = parse(None, source1, &tokens1[..], context1).unwrap();
 
-        let mut context2 = HashMap::<&str, usize>::new();
-        context2.insert("x", 0);
-        context2.insert("y", 1);
-
+        let context2 = ["x", "y"];
         let source2 = "x";
 
         let tokens2 = tokenize(None, source2).unwrap();
-        let node2 = parse(None, source2, &tokens2[..], &mut context2).unwrap();
+        let node2 = parse(None, source2, &tokens2[..], context2).unwrap();
 
         assert_eq!(syntactically_equal(node1, node2), false);
     }
 
     #[test]
     fn syntactically_equal_lambda() {
-        let mut context1 = HashMap::<&str, usize>::new();
-        context1.insert(TYPE, 0);
-
+        let context1 = [];
         let source1 = "(x : type) => x";
 
         let tokens1 = tokenize(None, source1).unwrap();
-        let node1 = parse(None, source1, &tokens1[..], &mut context1).unwrap();
+        let node1 = parse(None, source1, &tokens1[..], context1).unwrap();
 
-        let mut context2 = HashMap::<&str, usize>::new();
-        context2.insert(TYPE, 0);
-
+        let context2 = [];
         let source2 = "(x : type) => x";
 
         let tokens2 = tokenize(None, source2).unwrap();
-        let node2 = parse(None, source2, &tokens2[..], &mut context2).unwrap();
+        let node2 = parse(None, source2, &tokens2[..], context2).unwrap();
 
         assert_eq!(syntactically_equal(node1, node2), true);
     }
 
     #[test]
     fn syntactically_inequal_lambda_domain() {
-        let mut context1 = HashMap::<&str, usize>::new();
-        context1.insert(TYPE, 0);
-
+        let context1 = [];
         let source1 = "(x : type) => x";
 
         let tokens1 = tokenize(None, source1).unwrap();
-        let node1 = parse(None, source1, &tokens1[..], &mut context1).unwrap();
+        let node1 = parse(None, source1, &tokens1[..], context1).unwrap();
 
-        let mut context2 = HashMap::<&str, usize>::new();
-        context2.insert(TYPE, 0);
-
+        let context2 = [];
         let source2 = "(x : (type type)) => x";
 
         let tokens2 = tokenize(None, source2).unwrap();
-        let node2 = parse(None, source2, &tokens2[..], &mut context2).unwrap();
+        let node2 = parse(None, source2, &tokens2[..], context2).unwrap();
 
         assert_eq!(syntactically_equal(node1, node2), false);
     }
 
     #[test]
     fn syntactically_inequal_lambda_body() {
-        let mut context1 = HashMap::<&str, usize>::new();
-        context1.insert(TYPE, 0);
-
+        let context1 = [];
         let source1 = "(x : type) => x";
 
         let tokens1 = tokenize(None, source1).unwrap();
-        let node1 = parse(None, source1, &tokens1[..], &mut context1).unwrap();
+        let node1 = parse(None, source1, &tokens1[..], context1).unwrap();
 
-        let mut context2 = HashMap::<&str, usize>::new();
-        context2.insert(TYPE, 0);
-
+        let context2 = [];
         let source2 = "(x : type) => type";
 
         let tokens2 = tokenize(None, source2).unwrap();
-        let node2 = parse(None, source2, &tokens2[..], &mut context2).unwrap();
+        let node2 = parse(None, source2, &tokens2[..], context2).unwrap();
 
         assert_eq!(syntactically_equal(node1, node2), false);
     }
 
     #[test]
     fn syntactically_equal_pi() {
-        let mut context1 = HashMap::<&str, usize>::new();
-        context1.insert(TYPE, 0);
-
+        let context1 = [];
         let source1 = "(x : type) -> x";
 
         let tokens1 = tokenize(None, source1).unwrap();
-        let node1 = parse(None, source1, &tokens1[..], &mut context1).unwrap();
+        let node1 = parse(None, source1, &tokens1[..], context1).unwrap();
 
-        let mut context2 = HashMap::<&str, usize>::new();
-        context2.insert(TYPE, 0);
-
+        let context2 = [];
         let source2 = "(x : type) -> x";
 
         let tokens2 = tokenize(None, source2).unwrap();
-        let node2 = parse(None, source2, &tokens2[..], &mut context2).unwrap();
+        let node2 = parse(None, source2, &tokens2[..], context2).unwrap();
 
         assert_eq!(syntactically_equal(node1, node2), true);
     }
 
     #[test]
     fn syntactically_inequal_pi_domain() {
-        let mut context1 = HashMap::<&str, usize>::new();
-        context1.insert(TYPE, 0);
-
+        let context1 = [];
         let source1 = "(x : type) -> x";
 
         let tokens1 = tokenize(None, source1).unwrap();
-        let node1 = parse(None, source1, &tokens1[..], &mut context1).unwrap();
+        let node1 = parse(None, source1, &tokens1[..], context1).unwrap();
 
-        let mut context2 = HashMap::<&str, usize>::new();
-        context2.insert(TYPE, 0);
-
+        let context2 = [];
         let source2 = "(x : (type type)) -> x";
 
         let tokens2 = tokenize(None, source2).unwrap();
-        let node2 = parse(None, source2, &tokens2[..], &mut context2).unwrap();
+        let node2 = parse(None, source2, &tokens2[..], context2).unwrap();
 
         assert_eq!(syntactically_equal(node1, node2), false);
     }
 
     #[test]
     fn syntactically_inequal_pi() {
-        let mut context1 = HashMap::<&str, usize>::new();
-        context1.insert(TYPE, 0);
-
+        let context1 = [];
         let source1 = "(x : type) -> x";
 
         let tokens1 = tokenize(None, source1).unwrap();
-        let node1 = parse(None, source1, &tokens1[..], &mut context1).unwrap();
+        let node1 = parse(None, source1, &tokens1[..], context1).unwrap();
 
-        let mut context2 = HashMap::<&str, usize>::new();
-        context2.insert(TYPE, 0);
-
+        let context2 = [];
         let source2 = "(x : type) -> type";
 
         let tokens2 = tokenize(None, source2).unwrap();
-        let node2 = parse(None, source2, &tokens2[..], &mut context2).unwrap();
+        let node2 = parse(None, source2, &tokens2[..], context2).unwrap();
 
         assert_eq!(syntactically_equal(node1, node2), false);
     }
 
     #[test]
     fn syntactically_equal_application() {
-        let mut context1 = HashMap::<&str, usize>::new();
-        context1.insert("f", 0);
-        context1.insert("x", 1);
-
+        let context1 = ["f", "x"];
         let source1 = "f x";
 
         let tokens1 = tokenize(None, source1).unwrap();
-        let node1 = parse(None, source1, &tokens1[..], &mut context1).unwrap();
+        let node1 = parse(None, source1, &tokens1[..], context1).unwrap();
 
-        let mut context2 = HashMap::<&str, usize>::new();
-        context2.insert("f", 0);
-        context2.insert("x", 1);
-
+        let context2 = ["f", "x"];
         let source2 = "f x";
 
         let tokens2 = tokenize(None, source2).unwrap();
-        let node2 = parse(None, source2, &tokens2[..], &mut context2).unwrap();
+        let node2 = parse(None, source2, &tokens2[..], context2).unwrap();
 
         assert_eq!(syntactically_equal(node1, node2), true);
     }
 
     #[test]
     fn syntactically_inequal_application_applicand() {
-        let mut context1 = HashMap::<&str, usize>::new();
-        context1.insert("f", 0);
-        context1.insert("x", 1);
-
+        let context1 = ["f", "x"];
         let source1 = "f x";
 
         let tokens1 = tokenize(None, source1).unwrap();
-        let node1 = parse(None, source1, &tokens1[..], &mut context1).unwrap();
+        let node1 = parse(None, source1, &tokens1[..], context1).unwrap();
 
-        let mut context2 = HashMap::<&str, usize>::new();
-        context2.insert("f", 0);
-        context2.insert("x", 1);
-
+        let context2 = ["f", "x"];
         let source2 = "x x";
 
         let tokens2 = tokenize(None, source2).unwrap();
-        let node2 = parse(None, source2, &tokens2[..], &mut context2).unwrap();
+        let node2 = parse(None, source2, &tokens2[..], context2).unwrap();
 
         assert_eq!(syntactically_equal(node1, node2), false);
     }
 
     #[test]
-    fn syntactically_equal_argument() {
-        let mut context1 = HashMap::<&str, usize>::new();
-        context1.insert("f", 0);
-        context1.insert("x", 1);
-
+    fn syntactically_inequal_application_argument() {
+        let context1 = ["f", "x"];
         let source1 = "f x";
 
         let tokens1 = tokenize(None, source1).unwrap();
-        let node1 = parse(None, source1, &tokens1[..], &mut context1).unwrap();
+        let node1 = parse(None, source1, &tokens1[..], context1).unwrap();
 
-        let mut context2 = HashMap::<&str, usize>::new();
-        context2.insert("f", 0);
-        context2.insert("x", 1);
-
+        let context2 = ["f", "x"];
         let source2 = "f f";
 
         let tokens2 = tokenize(None, source2).unwrap();
-        let node2 = parse(None, source2, &tokens2[..], &mut context2).unwrap();
+        let node2 = parse(None, source2, &tokens2[..], context2).unwrap();
 
         assert_eq!(syntactically_equal(node1, node2), false);
     }
 
     #[test]
     fn definitionally_equal_beta() {
-        let mut context1 = HashMap::<&str, usize>::new();
-        context1.insert(TYPE, 0);
-        context1.insert("y", 1);
-
+        let context1 = ["y"];
         let source1 = "((x : type) => x x) y";
 
         let tokens1 = tokenize(None, source1).unwrap();
-        let node1 = parse(None, source1, &tokens1[..], &mut context1).unwrap();
+        let node1 = parse(None, source1, &tokens1[..], context1).unwrap();
 
-        let mut context2 = HashMap::<&str, usize>::new();
-        context2.insert("y", 0);
-
+        let context2 = ["y"];
         let source2 = "y y";
 
         let tokens2 = tokenize(None, source2).unwrap();
-        let node2 = parse(None, source2, &tokens2[..], &mut context2).unwrap();
+        let node2 = parse(None, source2, &tokens2[..], context2).unwrap();
 
         assert_eq!(definitionally_equal(node1, node2), true);
     }
 
     #[test]
     fn definitionally_inequal_beta() {
-        let mut context1 = HashMap::<&str, usize>::new();
-        context1.insert(TYPE, 0);
-        context1.insert("y", 1);
-
+        let context1 = ["y"];
         let source1 = "((x : type) => x x) y";
 
         let tokens1 = tokenize(None, source1).unwrap();
-        let node1 = parse(None, source1, &tokens1[..], &mut context1).unwrap();
+        let node1 = parse(None, source1, &tokens1[..], context1).unwrap();
 
-        let mut context2 = HashMap::<&str, usize>::new();
-        context2.insert("y", 0);
-
+        let context2 = ["y"];
         let source2 = "y";
 
         let tokens2 = tokenize(None, source2).unwrap();
-        let node2 = parse(None, source2, &tokens2[..], &mut context2).unwrap();
+        let node2 = parse(None, source2, &tokens2[..], context2).unwrap();
 
         assert_eq!(definitionally_equal(node1, node2), false);
     }

--- a/src/normalizer.rs
+++ b/src/normalizer.rs
@@ -67,19 +67,16 @@ mod tests {
         normalizer::normalize,
         parser::parse,
         tokenizer::tokenize,
-        type_checker::TYPE,
     };
-    use std::{collections::HashMap, rc::Rc};
+    use std::rc::Rc;
 
     #[test]
     fn normalize_variable() {
-        let mut context = HashMap::<&str, usize>::new();
-        context.insert("x", 0);
-
+        let context = ["x"];
         let source = "x";
 
         let tokens = tokenize(None, source).unwrap();
-        let node = parse(None, source, &tokens[..], &mut context).unwrap();
+        let node = parse(None, source, &tokens[..], context).unwrap();
 
         assert_eq!(
             *normalize(node),
@@ -93,15 +90,11 @@ mod tests {
 
     #[test]
     fn normalize_redex_under_lambda() {
-        let mut context = HashMap::<&str, usize>::new();
-        context.insert(TYPE, 0);
-        context.insert("p", 1);
-        context.insert("q", 2);
-
+        let context = ["p", "q"];
         let source = "(x : ((y : type) => y) p) => ((z : type) => z) q";
 
         let tokens = tokenize(None, source).unwrap();
-        let node = parse(None, source, &tokens[..], &mut context).unwrap();
+        let node = parse(None, source, &tokens[..], context).unwrap();
 
         assert_eq!(
             *normalize(node),
@@ -127,15 +120,11 @@ mod tests {
 
     #[test]
     fn normalize_redex_under_pi() {
-        let mut context = HashMap::<&str, usize>::new();
-        context.insert(TYPE, 0);
-        context.insert("p", 1);
-        context.insert("q", 2);
-
+        let context = ["p", "q"];
         let source = "(x : ((y : type) => y) p) -> ((z : type) => z) q";
 
         let tokens = tokenize(None, source).unwrap();
-        let node = parse(None, source, &tokens[..], &mut context).unwrap();
+        let node = parse(None, source, &tokens[..], context).unwrap();
 
         assert_eq!(
             *normalize(node),
@@ -161,15 +150,11 @@ mod tests {
 
     #[test]
     fn normalize_non_redex() {
-        let mut context = HashMap::<&str, usize>::new();
-        context.insert(TYPE, 0);
-        context.insert("y", 1);
-        context.insert("w", 2);
-
+        let context = ["y", "w"];
         let source = "(((x : type) => x) y) (((z : type) => z) w)";
 
         let tokens = tokenize(None, source).unwrap();
-        let node = parse(None, source, &tokens[..], &mut context).unwrap();
+        let node = parse(None, source, &tokens[..], context).unwrap();
 
         assert_eq!(
             *normalize(node),
@@ -194,14 +179,11 @@ mod tests {
 
     #[test]
     fn normalize_redex() {
-        let mut context = HashMap::<&str, usize>::new();
-        context.insert(TYPE, 0);
-        context.insert("y", 1);
-
+        let context = ["y"];
         let source = "((x : type) => x) y";
 
         let tokens = tokenize(None, source).unwrap();
-        let node = parse(None, source, &tokens[..], &mut context).unwrap();
+        let node = parse(None, source, &tokens[..], context).unwrap();
 
         assert_eq!(
             *normalize(node),


### PR DESCRIPTION
Simplify the structure of parsing and type checking contexts by implicitly assuming `TYPE` is at the front.