### PR TITLE
Stop using the `Borrow` and `BorrowMut` traits

### DIFF
--- a/src/de_bruijn.rs
+++ b/src/de_bruijn.rs
@@ -2,13 +2,10 @@ use crate::ast::{
     Node,
     Variant::{Application, Lambda, Pi, Variable},
 };
-use std::{borrow::Borrow, rc::Rc};
+use std::rc::Rc;
 
 // Shifting refers to increasing the De Bruijn indices of all free variables.
-pub fn shift<'a, T: Borrow<Node<'a>>>(node: T, depth: usize, amount: usize) -> Rc<Node<'a>> {
-    // Get references to the borrowed data.
-    let node = node.borrow();
-
+pub fn shift<'a>(node: &Node<'a>, depth: usize, amount: usize) -> Rc<Node<'a>> {
     // Recursively shift sub-nodes.
     match &node.variant {
         Variable(variable, index) => {
@@ -53,15 +50,11 @@ pub fn shift<'a, T: Borrow<Node<'a>>>(node: T, depth: usize, amount: usize) -> R
 
 // Opening is the act of replacing a free variable by a term and decrementing the De Bruijn indices
 // of the free variables that are to the left of the one being replaced in the context.
-pub fn open<'a, T: Borrow<Node<'a>>, U: Borrow<Node<'a>>>(
-    node_to_open: T,
+pub fn open<'a>(
+    node_to_open: &Node<'a>,
     index_to_replace: usize,
-    node_to_insert: U,
+    node_to_insert: &Node<'a>,
 ) -> Rc<Node<'a>> {
-    // Get references to the borrowed data.
-    let node_to_open = node_to_open.borrow();
-    let node_to_insert = node_to_insert.borrow();
-
     // Recursively open sub-nodes.
     match &node_to_open.variant {
         Variable(variable, index) => {
@@ -127,7 +120,7 @@ mod tests {
     fn shift_variable_free() {
         assert_eq!(
             *shift(
-                Node {
+                &Node {
                     source_range: Some((0, 1)),
                     group: false,
                     variant: Variable("x", 0),
@@ -147,7 +140,7 @@ mod tests {
     fn shift_variable_bound() {
         assert_eq!(
             *shift(
-                Node {
+                &Node {
                     source_range: Some((0, 1)),
                     group: false,
                     variant: Variable("x", 0),
@@ -167,7 +160,7 @@ mod tests {
     fn shift_lambda() {
         assert_eq!(
             *shift(
-                Node {
+                &Node {
                     source_range: Some((97, 112)),
                     group: false,
                     variant: Lambda(
@@ -211,7 +204,7 @@ mod tests {
     fn shift_pi() {
         assert_eq!(
             *shift(
-                Node {
+                &Node {
                     source_range: Some((97, 112)),
                     group: false,
                     variant: Pi(
@@ -255,7 +248,7 @@ mod tests {
     fn shift_application() {
         assert_eq!(
             *shift(
-                Node {
+                &Node {
                     source_range: Some((97, 112)),
                     group: false,
                     variant: Application(
@@ -297,13 +290,13 @@ mod tests {
     fn open_variable_match() {
         assert_eq!(
             *open(
-                Node {
+                &Node {
                     source_range: Some((0, 1)),
                     group: false,
                     variant: Variable("x", 0),
                 },
                 0,
-                Node {
+                &Node {
                     source_range: Some((3, 4)),
                     group: false,
                     variant: Variable("y", 0),
@@ -321,13 +314,13 @@ mod tests {
     fn open_variable_free() {
         assert_eq!(
             *open(
-                Node {
+                &Node {
                     source_range: Some((0, 1)),
                     group: false,
                     variant: Variable("x", 1),
                 },
                 0,
-                Node {
+                &Node {
                     source_range: Some((3, 4)),
                     group: false,
                     variant: Variable("y", 0),
@@ -345,13 +338,13 @@ mod tests {
     fn open_variable_bound() {
         assert_eq!(
             *open(
-                Node {
+                &Node {
                     source_range: Some((0, 1)),
                     group: false,
                     variant: Variable("x", 0),
                 },
                 1,
-                Node {
+                &Node {
                     source_range: Some((3, 4)),
                     group: false,
                     variant: Variable("y", 0),
@@ -369,7 +362,7 @@ mod tests {
     fn open_lambda() {
         assert_eq!(
             *open(
-                Node {
+                &Node {
                     source_range: Some((97, 112)),
                     group: false,
                     variant: Lambda(
@@ -387,7 +380,7 @@ mod tests {
                     ),
                 },
                 0,
-                Node {
+                &Node {
                     source_range: Some((3, 4)),
                     group: false,
                     variant: Variable("x", 4),
@@ -417,7 +410,7 @@ mod tests {
     fn open_pi() {
         assert_eq!(
             *open(
-                Node {
+                &Node {
                     source_range: Some((97, 112)),
                     group: false,
                     variant: Pi(
@@ -435,7 +428,7 @@ mod tests {
                     ),
                 },
                 0,
-                Node {
+                &Node {
                     source_range: Some((3, 4)),
                     group: false,
                     variant: Variable("x", 4),
@@ -465,7 +458,7 @@ mod tests {
     fn open_application() {
         assert_eq!(
             *open(
-                Node {
+                &Node {
                     source_range: Some((97, 112)),
                     group: false,
                     variant: Application(
@@ -482,7 +475,7 @@ mod tests {
                     ),
                 },
                 0,
-                Node {
+                &Node {
                     source_range: Some((3, 4)),
                     group: false,
                     variant: Variable("x", 4),

--- a/src/equality.rs
+++ b/src/equality.rs
@@ -5,17 +5,9 @@ use crate::{
     },
     normalizer::normalize,
 };
-use std::borrow::Borrow;
 
 // Check if two terms are equal up to alpha renaming.
-pub fn syntactically_equal<'a, T: Borrow<Node<'a>>, U: Borrow<Node<'a>>>(
-    node1: T,
-    node2: U,
-) -> bool {
-    // Get references to the borrowed data.
-    let node1 = node1.borrow();
-    let node2 = node2.borrow();
-
+pub fn syntactically_equal<'a>(node1: &Node<'a>, node2: &Node<'a>) -> bool {
     // Recursively check sub-nodes.
     match (&node1.variant, &node2.variant) {
         (Variable(_, index1), Variable(_, index2)) => index1 == index2,
@@ -35,16 +27,9 @@ pub fn syntactically_equal<'a, T: Borrow<Node<'a>>, U: Borrow<Node<'a>>>(
 }
 
 // Check if two terms are equal up to alpha renaming and beta/eta equivalence.
-pub fn definitionally_equal<'a, T: Borrow<Node<'a>>, U: Borrow<Node<'a>>>(
-    node1: T,
-    node2: U,
-) -> bool {
-    // Get references to the borrowed data.
-    let node1 = node1.borrow();
-    let node2 = node2.borrow();
-
+pub fn definitionally_equal<'a>(node1: &Node<'a>, node2: &Node<'a>) -> bool {
     // Check if the normalized terms are equal.
-    syntactically_equal(normalize(node1), normalize(node2))
+    syntactically_equal(&normalize(node1), &normalize(node2))
 }
 
 #[cfg(test)]
@@ -61,15 +46,15 @@ mod tests {
         let source1 = "x";
 
         let tokens1 = tokenize(None, source1).unwrap();
-        let node1 = parse(None, source1, &tokens1[..], context1).unwrap();
+        let node1 = parse(None, source1, &tokens1[..], &context1[..]).unwrap();
 
         let context2 = ["y"];
         let source2 = "y";
 
         let tokens2 = tokenize(None, source2).unwrap();
-        let node2 = parse(None, source2, &tokens2[..], context2).unwrap();
+        let node2 = parse(None, source2, &tokens2[..], &context2[..]).unwrap();
 
-        assert_eq!(syntactically_equal(node1, node2), true);
+        assert_eq!(syntactically_equal(&node1, &node2), true);
     }
 
     #[test]
@@ -78,15 +63,15 @@ mod tests {
         let source1 = "x";
 
         let tokens1 = tokenize(None, source1).unwrap();
-        let node1 = parse(None, source1, &tokens1[..], context1).unwrap();
+        let node1 = parse(None, source1, &tokens1[..], &context1[..]).unwrap();
 
         let context2 = ["x", "y"];
         let source2 = "x";
 
         let tokens2 = tokenize(None, source2).unwrap();
-        let node2 = parse(None, source2, &tokens2[..], context2).unwrap();
+        let node2 = parse(None, source2, &tokens2[..], &context2[..]).unwrap();
 
-        assert_eq!(syntactically_equal(node1, node2), false);
+        assert_eq!(syntactically_equal(&node1, &node2), false);
     }
 
     #[test]
@@ -95,15 +80,15 @@ mod tests {
         let source1 = "(x : type) => x";
 
         let tokens1 = tokenize(None, source1).unwrap();
-        let node1 = parse(None, source1, &tokens1[..], context1).unwrap();
+        let node1 = parse(None, source1, &tokens1[..], &context1[..]).unwrap();
 
         let context2 = [];
         let source2 = "(x : type) => x";
 
         let tokens2 = tokenize(None, source2).unwrap();
-        let node2 = parse(None, source2, &tokens2[..], context2).unwrap();
+        let node2 = parse(None, source2, &tokens2[..], &context2[..]).unwrap();
 
-        assert_eq!(syntactically_equal(node1, node2), true);
+        assert_eq!(syntactically_equal(&node1, &node2), true);
     }
 
     #[test]
@@ -112,15 +97,15 @@ mod tests {
         let source1 = "(x : type) => x";
 
         let tokens1 = tokenize(None, source1).unwrap();
-        let node1 = parse(None, source1, &tokens1[..], context1).unwrap();
+        let node1 = parse(None, source1, &tokens1[..], &context1[..]).unwrap();
 
         let context2 = [];
         let source2 = "(x : (type type)) => x";
 
         let tokens2 = tokenize(None, source2).unwrap();
-        let node2 = parse(None, source2, &tokens2[..], context2).unwrap();
+        let node2 = parse(None, source2, &tokens2[..], &context2[..]).unwrap();
 
-        assert_eq!(syntactically_equal(node1, node2), false);
+        assert_eq!(syntactically_equal(&node1, &node2), false);
     }
 
     #[test]
@@ -129,15 +114,15 @@ mod tests {
         let source1 = "(x : type) => x";
 
         let tokens1 = tokenize(None, source1).unwrap();
-        let node1 = parse(None, source1, &tokens1[..], context1).unwrap();
+        let node1 = parse(None, source1, &tokens1[..], &context1[..]).unwrap();
 
         let context2 = [];
         let source2 = "(x : type) => type";
 
         let tokens2 = tokenize(None, source2).unwrap();
-        let node2 = parse(None, source2, &tokens2[..], context2).unwrap();
+        let node2 = parse(None, source2, &tokens2[..], &context2[..]).unwrap();
 
-        assert_eq!(syntactically_equal(node1, node2), false);
+        assert_eq!(syntactically_equal(&node1, &node2), false);
     }
 
     #[test]
@@ -146,15 +131,15 @@ mod tests {
         let source1 = "(x : type) -> x";
 
         let tokens1 = tokenize(None, source1).unwrap();
-        let node1 = parse(None, source1, &tokens1[..], context1).unwrap();
+        let node1 = parse(None, source1, &tokens1[..], &context1[..]).unwrap();
 
         let context2 = [];
         let source2 = "(x : type) -> x";
 
         let tokens2 = tokenize(None, source2).unwrap();
-        let node2 = parse(None, source2, &tokens2[..], context2).unwrap();
+        let node2 = parse(None, source2, &tokens2[..], &context2[..]).unwrap();
 
-        assert_eq!(syntactically_equal(node1, node2), true);
+        assert_eq!(syntactically_equal(&node1, &node2), true);
     }
 
     #[test]
@@ -163,15 +148,15 @@ mod tests {
         let source1 = "(x : type) -> x";
 
         let tokens1 = tokenize(None, source1).unwrap();
-        let node1 = parse(None, source1, &tokens1[..], context1).unwrap();
+        let node1 = parse(None, source1, &tokens1[..], &context1[..]).unwrap();
 
         let context2 = [];
         let source2 = "(x : (type type)) -> x";
 
         let tokens2 = tokenize(None, source2).unwrap();
-        let node2 = parse(None, source2, &tokens2[..], context2).unwrap();
+        let node2 = parse(None, source2, &tokens2[..], &context2[..]).unwrap();
 
-        assert_eq!(syntactically_equal(node1, node2), false);
+        assert_eq!(syntactically_equal(&node1, &node2), false);
     }
 
     #[test]
@@ -180,15 +165,15 @@ mod tests {
         let source1 = "(x : type) -> x";
 
         let tokens1 = tokenize(None, source1).unwrap();
-        let node1 = parse(None, source1, &tokens1[..], context1).unwrap();
+        let node1 = parse(None, source1, &tokens1[..], &context1[..]).unwrap();
 
         let context2 = [];
         let source2 = "(x : type) -> type";
 
         let tokens2 = tokenize(None, source2).unwrap();
-        let node2 = parse(None, source2, &tokens2[..], context2).unwrap();
+        let node2 = parse(None, source2, &tokens2[..], &context2[..]).unwrap();
 
-        assert_eq!(syntactically_equal(node1, node2), false);
+        assert_eq!(syntactically_equal(&node1, &node2), false);
     }
 
     #[test]
@@ -197,15 +182,15 @@ mod tests {
         let source1 = "f x";
 
         let tokens1 = tokenize(None, source1).unwrap();
-        let node1 = parse(None, source1, &tokens1[..], context1).unwrap();
+        let node1 = parse(None, source1, &tokens1[..], &context1[..]).unwrap();
 
         let context2 = ["f", "x"];
         let source2 = "f x";
 
         let tokens2 = tokenize(None, source2).unwrap();
-        let node2 = parse(None, source2, &tokens2[..], context2).unwrap();
+        let node2 = parse(None, source2, &tokens2[..], &context2[..]).unwrap();
 
-        assert_eq!(syntactically_equal(node1, node2), true);
+        assert_eq!(syntactically_equal(&node1, &node2), true);
     }
 
     #[test]
@@ -214,15 +199,15 @@ mod tests {
         let source1 = "f x";
 
         let tokens1 = tokenize(None, source1).unwrap();
-        let node1 = parse(None, source1, &tokens1[..], context1).unwrap();
+        let node1 = parse(None, source1, &tokens1[..], &context1[..]).unwrap();
 
         let context2 = ["f", "x"];
         let source2 = "x x";
 
         let tokens2 = tokenize(None, source2).unwrap();
-        let node2 = parse(None, source2, &tokens2[..], context2).unwrap();
+        let node2 = parse(None, source2, &tokens2[..], &context2[..]).unwrap();
 
-        assert_eq!(syntactically_equal(node1, node2), false);
+        assert_eq!(syntactically_equal(&node1, &node2), false);
     }
 
     #[test]
@@ -231,15 +216,15 @@ mod tests {
         let source1 = "f x";
 
         let tokens1 = tokenize(None, source1).unwrap();
-        let node1 = parse(None, source1, &tokens1[..], context1).unwrap();
+        let node1 = parse(None, source1, &tokens1[..], &context1[..]).unwrap();
 
         let context2 = ["f", "x"];
         let source2 = "f f";
 
         let tokens2 = tokenize(None, source2).unwrap();
-        let node2 = parse(None, source2, &tokens2[..], context2).unwrap();
+        let node2 = parse(None, source2, &tokens2[..], &context2[..]).unwrap();
 
-        assert_eq!(syntactically_equal(node1, node2), false);
+        assert_eq!(syntactically_equal(&node1, &node2), false);
     }
 
     #[test]
@@ -248,15 +233,15 @@ mod tests {
         let source1 = "((x : type) => x x) y";
 
         let tokens1 = tokenize(None, source1).unwrap();
-        let node1 = parse(None, source1, &tokens1[..], context1).unwrap();
+        let node1 = parse(None, source1, &tokens1[..], &context1[..]).unwrap();
 
         let context2 = ["y"];
         let source2 = "y y";
 
         let tokens2 = tokenize(None, source2).unwrap();
-        let node2 = parse(None, source2, &tokens2[..], context2).unwrap();
+        let node2 = parse(None, source2, &tokens2[..], &context2[..]).unwrap();
 
-        assert_eq!(definitionally_equal(node1, node2), true);
+        assert_eq!(definitionally_equal(&node1, &node2), true);
     }
 
     #[test]
@@ -265,14 +250,14 @@ mod tests {
         let source1 = "((x : type) => x x) y";
 
         let tokens1 = tokenize(None, source1).unwrap();
-        let node1 = parse(None, source1, &tokens1[..], context1).unwrap();
+        let node1 = parse(None, source1, &tokens1[..], &context1[..]).unwrap();
 
         let context2 = ["y"];
         let source2 = "y";
 
         let tokens2 = tokenize(None, source2).unwrap();
-        let node2 = parse(None, source2, &tokens2[..], context2).unwrap();
+        let node2 = parse(None, source2, &tokens2[..], &context2[..]).unwrap();
 
-        assert_eq!(definitionally_equal(node1, node2), false);
+        assert_eq!(definitionally_equal(&node1, &node2), false);
     }
 }

--- a/src/normalizer.rs
+++ b/src/normalizer.rs
@@ -5,13 +5,10 @@ use crate::{
     },
     de_bruijn::open,
 };
-use std::{borrow::Borrow, rc::Rc};
+use std::rc::Rc;
 
 // This function reduces a term to beta normal form using applicative order reduction.
-pub fn normalize<'a, T: Borrow<Node<'a>>>(node: T) -> Rc<Node<'a>> {
-    // Get references to the borrowed data.
-    let node = node.borrow();
-
+pub fn normalize<'a>(node: &Node<'a>) -> Rc<Node<'a>> {
     // Recursively normalize sub-nodes.
     match &node.variant {
         Variable(_, _) => {
@@ -44,7 +41,7 @@ pub fn normalize<'a, T: Borrow<Node<'a>>>(node: T) -> Rc<Node<'a>> {
             // Check if the applicand reduced to a lambda.
             if let Lambda(_, _, body) = &normalized_applicand.variant {
                 // We got a lambda. Perform beta reduction.
-                normalize(open(&**body, 0, normalized_argument))
+                normalize(&open(&**body, 0, &normalized_argument))
             } else {
                 // We didn't get a lambda. Just reduce the argument.
                 Rc::new(Node {
@@ -76,10 +73,10 @@ mod tests {
         let source = "x";
 
         let tokens = tokenize(None, source).unwrap();
-        let node = parse(None, source, &tokens[..], context).unwrap();
+        let node = parse(None, source, &tokens[..], &context[..]).unwrap();
 
         assert_eq!(
-            *normalize(node),
+            *normalize(&node),
             Node {
                 source_range: Some((0, 1)),
                 group: false,
@@ -94,10 +91,10 @@ mod tests {
         let source = "(x : ((y : type) => y) p) => ((z : type) => z) q";
 
         let tokens = tokenize(None, source).unwrap();
-        let node = parse(None, source, &tokens[..], context).unwrap();
+        let node = parse(None, source, &tokens[..], &context[..]).unwrap();
 
         assert_eq!(
-            *normalize(node),
+            *normalize(&node),
             Node {
                 source_range: Some((0, 48)),
                 group: true,
@@ -124,10 +121,10 @@ mod tests {
         let source = "(x : ((y : type) => y) p) -> ((z : type) => z) q";
 
         let tokens = tokenize(None, source).unwrap();
-        let node = parse(None, source, &tokens[..], context).unwrap();
+        let node = parse(None, source, &tokens[..], &context[..]).unwrap();
 
         assert_eq!(
-            *normalize(node),
+            *normalize(&node),
             Node {
                 source_range: Some((0, 48)),
                 group: true,
@@ -154,10 +151,10 @@ mod tests {
         let source = "(((x : type) => x) y) (((z : type) => z) w)";
 
         let tokens = tokenize(None, source).unwrap();
-        let node = parse(None, source, &tokens[..], context).unwrap();
+        let node = parse(None, source, &tokens[..], &context[..]).unwrap();
 
         assert_eq!(
-            *normalize(node),
+            *normalize(&node),
             Node {
                 source_range: Some((2, 42)),
                 group: true,
@@ -183,10 +180,10 @@ mod tests {
         let source = "((x : type) => x) y";
 
         let tokens = tokenize(None, source).unwrap();
-        let node = parse(None, source, &tokens[..], context).unwrap();
+        let node = parse(None, source, &tokens[..], &context[..]).unwrap();
 
         assert_eq!(
-            *normalize(node),
+            *normalize(&node),
             Node {
                 source_range: Some((18, 19)),
                 group: true,

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -52,7 +52,7 @@ pub fn tokenize<'a>(
                     });
                 } else {
                     return Err(throw(
-                        format!(
+                        &format!(
                             "Unexpected symbol {}.",
                             &source_contents[i..i + c.len_utf8()].code_str(),
                         ),
@@ -71,7 +71,7 @@ pub fn tokenize<'a>(
                     });
                 } else {
                     return Err(throw(
-                        format!(
+                        &format!(
                             "Unexpected symbol {}.",
                             &source_contents[i..i + c.len_utf8()].code_str(),
                         ),
@@ -117,7 +117,7 @@ pub fn tokenize<'a>(
             // If we made it this far, the input contains something unexpected.
             _ => {
                 return Err(throw(
-                    format!(
+                    &format!(
                         "Unexpected symbol {}.",
                         &source_contents[i..i + c.len_utf8()].code_str(),
                     ),


### PR DESCRIPTION
Stop using the `Borrow` and `BorrowMut` traits. They add unnecessary complexity (especially in the form of syntactic boilerplate/noise) without providing much value over plain old references.