### PR TITLE
Rename `Node` to `Term` to be more precise

### DIFF
--- a/src/de_bruijn.rs
+++ b/src/de_bruijn.rs
@@ -1,46 +1,46 @@
-use crate::ast::{
-    Node,
+use crate::term::{
+    Term,
     Variant::{Application, Lambda, Pi, Variable},
 };
 use std::rc::Rc;
 
 // Shifting refers to increasing the De Bruijn indices of free variables greater than or equal to a
 // given index.
-pub fn shift<'a>(node: &Node<'a>, min_index: usize, amount: usize) -> Rc<Node<'a>> {
-    // Recursively shift sub-nodes.
-    match &node.variant {
+pub fn shift<'a>(term: &Term<'a>, min_index: usize, amount: usize) -> Rc<Term<'a>> {
+    // Recursively shift sub-terms.
+    match &term.variant {
         Variable(variable, index) => {
             if *index >= min_index {
-                Rc::new(Node {
-                    source_range: node.source_range,
-                    group: node.group,
+                Rc::new(Term {
+                    source_range: term.source_range,
+                    group: term.group,
                     variant: Variable(variable, index + amount),
                 })
             } else {
-                Rc::new(node.clone())
+                Rc::new(term.clone())
             }
         }
-        Lambda(variable, domain, body) => Rc::new(Node {
-            source_range: node.source_range,
-            group: node.group,
+        Lambda(variable, domain, body) => Rc::new(Term {
+            source_range: term.source_range,
+            group: term.group,
             variant: Lambda(
                 variable,
                 shift(&**domain, min_index, amount),
                 shift(&**body, min_index + 1, amount),
             ),
         }),
-        Pi(variable, domain, codomain) => Rc::new(Node {
-            source_range: node.source_range,
-            group: node.group,
+        Pi(variable, domain, codomain) => Rc::new(Term {
+            source_range: term.source_range,
+            group: term.group,
             variant: Pi(
                 variable,
                 shift(&**domain, min_index, amount),
                 shift(&**codomain, min_index + 1, amount),
             ),
         }),
-        Application(applicand, argument) => Rc::new(Node {
-            source_range: node.source_range,
-            group: node.group,
+        Application(applicand, argument) => Rc::new(Term {
+            source_range: term.source_range,
+            group: term.group,
             variant: Application(
                 shift(&**applicand, min_index, amount),
                 shift(&**argument, min_index, amount),
@@ -52,55 +52,55 @@ pub fn shift<'a>(node: &Node<'a>, min_index: usize, amount: usize) -> Rc<Node<'a
 // Opening is the act of replacing a free variable by a term and decrementing the De Bruijn indices
 // of the free variables with higher indices than that of the one being replaced.
 pub fn open<'a>(
-    node_to_open: &Node<'a>,
+    term_to_open: &Term<'a>,
     index_to_replace: usize,
-    node_to_insert: &Node<'a>,
-) -> Rc<Node<'a>> {
-    // Recursively open sub-nodes.
-    match &node_to_open.variant {
+    term_to_insert: &Term<'a>,
+) -> Rc<Term<'a>> {
+    // Recursively open sub-terms.
+    match &term_to_open.variant {
         Variable(variable, index) => {
             if *index > index_to_replace {
-                Rc::new(Node {
-                    source_range: node_to_open.source_range,
-                    group: node_to_open.group,
+                Rc::new(Term {
+                    source_range: term_to_open.source_range,
+                    group: term_to_open.group,
                     variant: Variable(variable, index - 1),
                 })
             } else if *index < index_to_replace {
-                Rc::new(node_to_open.clone())
+                Rc::new(term_to_open.clone())
             } else {
-                let shifted_node = shift(node_to_insert, 0, index_to_replace);
+                let shifted_term = shift(term_to_insert, 0, index_to_replace);
 
-                Rc::new(Node {
-                    source_range: shifted_node.source_range,
-                    group: true, // To ensure the resulting node is still parse-able when printed
-                    variant: shifted_node.variant.clone(),
+                Rc::new(Term {
+                    source_range: shifted_term.source_range,
+                    group: true, // To ensure the resulting term is still parse-able when printed
+                    variant: shifted_term.variant.clone(),
                 })
             }
         }
-        Lambda(variable, domain, body) => Rc::new(Node {
-            source_range: node_to_open.source_range,
-            group: true, // To ensure the resulting node is still parse-able when printed
+        Lambda(variable, domain, body) => Rc::new(Term {
+            source_range: term_to_open.source_range,
+            group: true, // To ensure the resulting term is still parse-able when printed
             variant: Lambda(
                 variable,
-                open(&**domain, index_to_replace, node_to_insert),
-                open(&**body, index_to_replace + 1, node_to_insert),
+                open(&**domain, index_to_replace, term_to_insert),
+                open(&**body, index_to_replace + 1, term_to_insert),
             ),
         }),
-        Pi(variable, domain, codomain) => Rc::new(Node {
-            source_range: node_to_open.source_range,
-            group: true, // To ensure the resulting node is still parse-able when printed
+        Pi(variable, domain, codomain) => Rc::new(Term {
+            source_range: term_to_open.source_range,
+            group: true, // To ensure the resulting term is still parse-able when printed
             variant: Pi(
                 variable,
-                open(&**domain, index_to_replace, node_to_insert),
-                open(&**codomain, index_to_replace + 1, node_to_insert),
+                open(&**domain, index_to_replace, term_to_insert),
+                open(&**codomain, index_to_replace + 1, term_to_insert),
             ),
         }),
-        Application(applicand, argument) => Rc::new(Node {
-            source_range: node_to_open.source_range,
-            group: true, // To ensure the resulting node is still parse-able when printed
+        Application(applicand, argument) => Rc::new(Term {
+            source_range: term_to_open.source_range,
+            group: true, // To ensure the resulting term is still parse-able when printed
             variant: Application(
-                open(&**applicand, index_to_replace, node_to_insert),
-                open(&**argument, index_to_replace, node_to_insert),
+                open(&**applicand, index_to_replace, term_to_insert),
+                open(&**argument, index_to_replace, term_to_insert),
             ),
         }),
     }
@@ -109,11 +109,11 @@ pub fn open<'a>(
 #[cfg(test)]
 mod tests {
     use crate::{
-        ast::{
-            Node,
+        de_bruijn::{open, shift},
+        term::{
+            Term,
             Variant::{Application, Lambda, Pi, Variable},
         },
-        de_bruijn::{open, shift},
     };
     use std::rc::Rc;
 
@@ -121,7 +121,7 @@ mod tests {
     fn shift_variable_free() {
         assert_eq!(
             *shift(
-                &Node {
+                &Term {
                     source_range: Some((0, 1)),
                     group: false,
                     variant: Variable("x", 0),
@@ -129,7 +129,7 @@ mod tests {
                 0,
                 42,
             ),
-            Node {
+            Term {
                 source_range: Some((0, 1)),
                 group: false,
                 variant: Variable("x", 42),
@@ -141,7 +141,7 @@ mod tests {
     fn shift_variable_bound() {
         assert_eq!(
             *shift(
-                &Node {
+                &Term {
                     source_range: Some((0, 1)),
                     group: false,
                     variant: Variable("x", 0),
@@ -149,7 +149,7 @@ mod tests {
                 1,
                 42,
             ),
-            Node {
+            Term {
                 source_range: Some((0, 1)),
                 group: false,
                 variant: Variable("x", 0),
@@ -161,17 +161,17 @@ mod tests {
     fn shift_lambda() {
         assert_eq!(
             *shift(
-                &Node {
+                &Term {
                     source_range: Some((97, 112)),
                     group: false,
                     variant: Lambda(
                         "a",
-                        Rc::new(Node {
+                        Rc::new(Term {
                             source_range: Some((102, 106)),
                             group: false,
                             variant: Variable("b", 0),
                         }),
-                        Rc::new(Node {
+                        Rc::new(Term {
                             source_range: Some((111, 112)),
                             group: false,
                             variant: Variable("b", 1),
@@ -181,17 +181,17 @@ mod tests {
                 0,
                 42,
             ),
-            Node {
+            Term {
                 source_range: Some((97, 112)),
                 group: false,
                 variant: Lambda(
                     "a",
-                    Rc::new(Node {
+                    Rc::new(Term {
                         source_range: Some((102, 106)),
                         group: false,
                         variant: Variable("b", 42),
                     }),
-                    Rc::new(Node {
+                    Rc::new(Term {
                         source_range: Some((111, 112)),
                         group: false,
                         variant: Variable("b", 43),
@@ -205,17 +205,17 @@ mod tests {
     fn shift_pi() {
         assert_eq!(
             *shift(
-                &Node {
+                &Term {
                     source_range: Some((97, 112)),
                     group: false,
                     variant: Pi(
                         "a",
-                        Rc::new(Node {
+                        Rc::new(Term {
                             source_range: Some((102, 106)),
                             group: false,
                             variant: Variable("b", 0),
                         }),
-                        Rc::new(Node {
+                        Rc::new(Term {
                             source_range: Some((111, 112)),
                             group: false,
                             variant: Variable("b", 1),
@@ -225,17 +225,17 @@ mod tests {
                 0,
                 42,
             ),
-            Node {
+            Term {
                 source_range: Some((97, 112)),
                 group: false,
                 variant: Pi(
                     "a",
-                    Rc::new(Node {
+                    Rc::new(Term {
                         source_range: Some((102, 106)),
                         group: false,
                         variant: Variable("b", 42),
                     }),
-                    Rc::new(Node {
+                    Rc::new(Term {
                         source_range: Some((111, 112)),
                         group: false,
                         variant: Variable("b", 43),
@@ -249,16 +249,16 @@ mod tests {
     fn shift_application() {
         assert_eq!(
             *shift(
-                &Node {
+                &Term {
                     source_range: Some((97, 112)),
                     group: false,
                     variant: Application(
-                        Rc::new(Node {
+                        Rc::new(Term {
                             source_range: Some((102, 106)),
                             group: false,
                             variant: Variable("a", 0),
                         }),
-                        Rc::new(Node {
+                        Rc::new(Term {
                             source_range: Some((111, 112)),
                             group: false,
                             variant: Variable("b", 1),
@@ -268,16 +268,16 @@ mod tests {
                 1,
                 42,
             ),
-            Node {
+            Term {
                 source_range: Some((97, 112)),
                 group: false,
                 variant: Application(
-                    Rc::new(Node {
+                    Rc::new(Term {
                         source_range: Some((102, 106)),
                         group: false,
                         variant: Variable("a", 0),
                     }),
-                    Rc::new(Node {
+                    Rc::new(Term {
                         source_range: Some((111, 112)),
                         group: false,
                         variant: Variable("b", 43),
@@ -291,19 +291,19 @@ mod tests {
     fn open_variable_match() {
         assert_eq!(
             *open(
-                &Node {
+                &Term {
                     source_range: Some((0, 1)),
                     group: false,
                     variant: Variable("x", 0),
                 },
                 0,
-                &Node {
+                &Term {
                     source_range: Some((3, 4)),
                     group: false,
                     variant: Variable("y", 0),
                 },
             ),
-            Node {
+            Term {
                 source_range: Some((3, 4)),
                 group: true,
                 variant: Variable("y", 0),
@@ -315,19 +315,19 @@ mod tests {
     fn open_variable_free() {
         assert_eq!(
             *open(
-                &Node {
+                &Term {
                     source_range: Some((0, 1)),
                     group: false,
                     variant: Variable("x", 1),
                 },
                 0,
-                &Node {
+                &Term {
                     source_range: Some((3, 4)),
                     group: false,
                     variant: Variable("y", 0),
                 },
             ),
-            Node {
+            Term {
                 source_range: Some((0, 1)),
                 group: false,
                 variant: Variable("x", 0),
@@ -339,19 +339,19 @@ mod tests {
     fn open_variable_bound() {
         assert_eq!(
             *open(
-                &Node {
+                &Term {
                     source_range: Some((0, 1)),
                     group: false,
                     variant: Variable("x", 0),
                 },
                 1,
-                &Node {
+                &Term {
                     source_range: Some((3, 4)),
                     group: false,
                     variant: Variable("y", 0),
                 },
             ),
-            Node {
+            Term {
                 source_range: Some((0, 1)),
                 group: false,
                 variant: Variable("x", 0),
@@ -363,17 +363,17 @@ mod tests {
     fn open_lambda() {
         assert_eq!(
             *open(
-                &Node {
+                &Term {
                     source_range: Some((97, 112)),
                     group: false,
                     variant: Lambda(
                         "a",
-                        Rc::new(Node {
+                        Rc::new(Term {
                             source_range: Some((102, 106)),
                             group: false,
                             variant: Variable("b", 0),
                         }),
-                        Rc::new(Node {
+                        Rc::new(Term {
                             source_range: Some((111, 112)),
                             group: false,
                             variant: Variable("b", 1),
@@ -381,23 +381,23 @@ mod tests {
                     ),
                 },
                 0,
-                &Node {
+                &Term {
                     source_range: Some((3, 4)),
                     group: false,
                     variant: Variable("x", 4),
                 },
             ),
-            Node {
+            Term {
                 source_range: Some((97, 112)),
                 group: true,
                 variant: Lambda(
                     "a",
-                    Rc::new(Node {
+                    Rc::new(Term {
                         source_range: Some((3, 4)),
                         group: true,
                         variant: Variable("x", 4),
                     }),
-                    Rc::new(Node {
+                    Rc::new(Term {
                         source_range: Some((3, 4)),
                         group: true,
                         variant: Variable("x", 5),
@@ -411,17 +411,17 @@ mod tests {
     fn open_pi() {
         assert_eq!(
             *open(
-                &Node {
+                &Term {
                     source_range: Some((97, 112)),
                     group: false,
                     variant: Pi(
                         "a",
-                        Rc::new(Node {
+                        Rc::new(Term {
                             source_range: Some((102, 106)),
                             group: false,
                             variant: Variable("b", 0),
                         }),
-                        Rc::new(Node {
+                        Rc::new(Term {
                             source_range: Some((111, 112)),
                             group: false,
                             variant: Variable("b", 1),
@@ -429,23 +429,23 @@ mod tests {
                     ),
                 },
                 0,
-                &Node {
+                &Term {
                     source_range: Some((3, 4)),
                     group: false,
                     variant: Variable("x", 4),
                 },
             ),
-            Node {
+            Term {
                 source_range: Some((97, 112)),
                 group: true,
                 variant: Pi(
                     "a",
-                    Rc::new(Node {
+                    Rc::new(Term {
                         source_range: Some((3, 4)),
                         group: true,
                         variant: Variable("x", 4),
                     }),
-                    Rc::new(Node {
+                    Rc::new(Term {
                         source_range: Some((3, 4)),
                         group: true,
                         variant: Variable("x", 5),
@@ -459,16 +459,16 @@ mod tests {
     fn open_application() {
         assert_eq!(
             *open(
-                &Node {
+                &Term {
                     source_range: Some((97, 112)),
                     group: false,
                     variant: Application(
-                        Rc::new(Node {
+                        Rc::new(Term {
                             source_range: Some((102, 106)),
                             group: false,
                             variant: Variable("a", 0),
                         }),
-                        Rc::new(Node {
+                        Rc::new(Term {
                             source_range: Some((111, 112)),
                             group: false,
                             variant: Variable("b", 1),
@@ -476,22 +476,22 @@ mod tests {
                     ),
                 },
                 0,
-                &Node {
+                &Term {
                     source_range: Some((3, 4)),
                     group: false,
                     variant: Variable("x", 4),
                 },
             ),
-            Node {
+            Term {
                 source_range: Some((97, 112)),
                 group: true,
                 variant: Application(
-                    Rc::new(Node {
+                    Rc::new(Term {
                         source_range: Some((3, 4)),
                         group: true,
                         variant: Variable("x", 4),
                     }),
-                    Rc::new(Node {
+                    Rc::new(Term {
                         source_range: Some((111, 112)),
                         group: false,
                         variant: Variable("b", 0),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,10 @@
-mod ast;
 mod de_bruijn;
 mod equality;
 mod error;
 mod format;
 mod normalizer;
 mod parser;
+mod term;
 mod token;
 mod tokenizer;
 mod type_checker;
@@ -107,19 +107,19 @@ fn run(source_path: &Path) -> Result<(), Error> {
     let tokens = tokenize(Some(source_path), &source_contents)?;
 
     // Parse the source file.
-    let node = parse(Some(source_path), &source_contents, &tokens[..], &[])?;
+    let term = parse(Some(source_path), &source_contents, &tokens[..], &[])?;
 
     // Print the AST.
-    println!("# Original term:\n\n{}\n", node);
+    println!("# Original term:\n\n{}\n", term);
 
     // Print the normal form.
-    println!("# Normal form:\n\n{}\n", normalize(&node));
+    println!("# Normal form:\n\n{}\n", normalize(&term));
 
     // Type check the AST.
-    let node_type = type_check(Some(source_path), &source_contents, &node, &mut vec![])?;
+    let term_type = type_check(Some(source_path), &source_contents, &term, &mut vec![])?;
 
     // Normalize and print the type.
-    println!("# Type:\n\n{}", normalize(&node_type));
+    println!("# Type:\n\n{}", normalize(&term_type));
 
     // If we made it this far, nothing went wrong.
     Ok(())

--- a/src/normalizer.rs
+++ b/src/normalizer.rs
@@ -1,33 +1,33 @@
 use crate::{
-    ast::{
-        Node,
+    de_bruijn::open,
+    term::{
+        Term,
         Variant::{Application, Lambda, Pi, Variable},
     },
-    de_bruijn::open,
 };
 use std::rc::Rc;
 
 // This function reduces a term to beta normal form using applicative order reduction.
-pub fn normalize<'a>(node: &Node<'a>) -> Rc<Node<'a>> {
-    // Recursively normalize sub-nodes.
-    match &node.variant {
+pub fn normalize<'a>(term: &Term<'a>) -> Rc<Term<'a>> {
+    // Recursively normalize sub-terms.
+    match &term.variant {
         Variable(_, _) => {
             // Variables are already in beta normal form.
-            Rc::new(node.clone())
+            Rc::new(term.clone())
         }
         Lambda(variable, domain, body) => {
             // For lambdas, we simply reduce the domain and body.
-            Rc::new(Node {
-                source_range: node.source_range,
-                group: true, // To ensure the resulting node is still parse-able when printed
+            Rc::new(Term {
+                source_range: term.source_range,
+                group: true, // To ensure the resulting term is still parse-able when printed
                 variant: Lambda(variable, normalize(&**domain), normalize(&**body)),
             })
         }
         Pi(variable, domain, codomain) => {
             // For pi types, we simply reduce the domain and codomain.
-            Rc::new(Node {
-                source_range: node.source_range,
-                group: true, // To ensure the resulting node is still parse-able when printed
+            Rc::new(Term {
+                source_range: term.source_range,
+                group: true, // To ensure the resulting term is still parse-able when printed
                 variant: Pi(variable, normalize(&**domain), normalize(&**codomain)),
             })
         }
@@ -44,9 +44,9 @@ pub fn normalize<'a>(node: &Node<'a>) -> Rc<Node<'a>> {
                 normalize(&open(&**body, 0, &normalized_argument))
             } else {
                 // We didn't get a lambda. Just reduce the argument.
-                Rc::new(Node {
-                    source_range: node.source_range,
-                    group: true, // To ensure the resulting node is still parse-able when printed
+                Rc::new(Term {
+                    source_range: term.source_range,
+                    group: true, // To ensure the resulting term is still parse-able when printed
                     variant: Application(normalized_applicand, normalized_argument),
                 })
             }
@@ -57,12 +57,12 @@ pub fn normalize<'a>(node: &Node<'a>) -> Rc<Node<'a>> {
 #[cfg(test)]
 mod tests {
     use crate::{
-        ast::{
-            Node,
-            Variant::{Application, Lambda, Pi, Variable},
-        },
         normalizer::normalize,
         parser::parse,
+        term::{
+            Term,
+            Variant::{Application, Lambda, Pi, Variable},
+        },
         tokenizer::tokenize,
     };
     use std::rc::Rc;
@@ -73,11 +73,11 @@ mod tests {
         let source = "x";
 
         let tokens = tokenize(None, source).unwrap();
-        let node = parse(None, source, &tokens[..], &context[..]).unwrap();
+        let term = parse(None, source, &tokens[..], &context[..]).unwrap();
 
         assert_eq!(
-            *normalize(&node),
-            Node {
+            *normalize(&term),
+            Term {
                 source_range: Some((0, 1)),
                 group: false,
                 variant: Variable("x", 0),
@@ -91,21 +91,21 @@ mod tests {
         let source = "(x : ((y : type) => y) p) => ((z : type) => z) q";
 
         let tokens = tokenize(None, source).unwrap();
-        let node = parse(None, source, &tokens[..], &context[..]).unwrap();
+        let term = parse(None, source, &tokens[..], &context[..]).unwrap();
 
         assert_eq!(
-            *normalize(&node),
-            Node {
+            *normalize(&term),
+            Term {
                 source_range: Some((0, 48)),
                 group: true,
                 variant: Lambda(
                     "x",
-                    Rc::new(Node {
+                    Rc::new(Term {
                         source_range: Some((23, 24)),
                         group: true,
                         variant: Variable("p", 1),
                     }),
-                    Rc::new(Node {
+                    Rc::new(Term {
                         source_range: Some((47, 48)),
                         group: true,
                         variant: Variable("q", 1),
@@ -121,21 +121,21 @@ mod tests {
         let source = "(x : ((y : type) => y) p) -> ((z : type) => z) q";
 
         let tokens = tokenize(None, source).unwrap();
-        let node = parse(None, source, &tokens[..], &context[..]).unwrap();
+        let term = parse(None, source, &tokens[..], &context[..]).unwrap();
 
         assert_eq!(
-            *normalize(&node),
-            Node {
+            *normalize(&term),
+            Term {
                 source_range: Some((0, 48)),
                 group: true,
                 variant: Pi(
                     "x",
-                    Rc::new(Node {
+                    Rc::new(Term {
                         source_range: Some((23, 24)),
                         group: true,
                         variant: Variable("p", 1),
                     }),
-                    Rc::new(Node {
+                    Rc::new(Term {
                         source_range: Some((47, 48)),
                         group: true,
                         variant: Variable("q", 1),
@@ -151,20 +151,20 @@ mod tests {
         let source = "(((x : type) => x) y) (((z : type) => z) w)";
 
         let tokens = tokenize(None, source).unwrap();
-        let node = parse(None, source, &tokens[..], &context[..]).unwrap();
+        let term = parse(None, source, &tokens[..], &context[..]).unwrap();
 
         assert_eq!(
-            *normalize(&node),
-            Node {
+            *normalize(&term),
+            Term {
                 source_range: Some((2, 42)),
                 group: true,
                 variant: Application(
-                    Rc::new(Node {
+                    Rc::new(Term {
                         source_range: Some((19, 20)),
                         group: true,
                         variant: Variable("y", 1),
                     }),
-                    Rc::new(Node {
+                    Rc::new(Term {
                         source_range: Some((41, 42)),
                         group: true,
                         variant: Variable("w", 0),
@@ -180,11 +180,11 @@ mod tests {
         let source = "((x : type) => x) y";
 
         let tokens = tokenize(None, source).unwrap();
-        let node = parse(None, source, &tokens[..], &context[..]).unwrap();
+        let term = parse(None, source, &tokens[..], &context[..]).unwrap();
 
         assert_eq!(
-            *normalize(&node),
-            Node {
+            *normalize(&term),
+            Term {
                 source_range: Some((18, 19)),
                 group: true,
                 variant: Variable("y", 0),

--- a/src/term.rs
+++ b/src/term.rs
@@ -6,13 +6,13 @@ use std::{
 // The token stream is parsed into an abstract syntax tree (AST). This struct represents a node in
 // an AST.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Node<'a> {
+pub struct Term<'a> {
     pub source_range: Option<(usize, usize)>, // [start, end)
     pub group: bool, // For an explanation of this field, see [ref:group-flag].
     pub variant: Variant<'a>,
 }
 
-// We assign each node a "variant" describing what kind of node it is.
+// Each term has a "variant" describing what kind of term it is.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Variant<'a> {
     // A variable is a placeholder bound by a lambda or a pi type. The integer is the De Bruijn
@@ -20,16 +20,16 @@ pub enum Variant<'a> {
     Variable(&'a str, usize),
 
     // A lambda, or dependent function, is a computable function.
-    Lambda(&'a str, Rc<Node<'a>>, Rc<Node<'a>>),
+    Lambda(&'a str, Rc<Term<'a>>, Rc<Term<'a>>),
 
     // Pi types, or dependent function types, are the types ascribed to lambdas.
-    Pi(&'a str, Rc<Node<'a>>, Rc<Node<'a>>),
+    Pi(&'a str, Rc<Term<'a>>, Rc<Term<'a>>),
 
     // An application is the act of applying a lambda to an argument.
-    Application(Rc<Node<'a>>, Rc<Node<'a>>),
+    Application(Rc<Term<'a>>, Rc<Term<'a>>),
 }
 
-impl<'a> Display for Node<'a> {
+impl<'a> Display for Term<'a> {
     fn fmt(&self, f: &mut Formatter) -> Result {
         if self.group {
             write!(f, "(")?;


### PR DESCRIPTION
Rename `Node` to `Term` to be more precise.