### PR TITLE
Make `type` a keyword rather than a variable with weird special behavior

### DIFF
--- a/src/equality.rs
+++ b/src/equality.rs
@@ -2,7 +2,7 @@ use crate::{
     normalizer::normalize,
     term::{
         Term,
-        Variant::{Application, Lambda, Pi, Variable},
+        Variant::{Application, Lambda, Pi, Type, Variable},
     },
 };
 
@@ -10,6 +10,7 @@ use crate::{
 pub fn syntactically_equal<'a>(term1: &Term<'a>, term2: &Term<'a>) -> bool {
     // Recursively check sub-terms.
     match (&term1.variant, &term2.variant) {
+        (Type, Type) => true,
         (Variable(_, index1), Variable(_, index2)) => index1 == index2,
         (Lambda(_, domain1, body1), Lambda(_, domain2, body2)) => {
             syntactically_equal(&**domain1, &**domain2) && syntactically_equal(&**body1, &**body2)
@@ -37,8 +38,26 @@ mod tests {
     use crate::{
         equality::{definitionally_equal, syntactically_equal},
         parser::parse,
+        token::TYPE,
         tokenizer::tokenize,
     };
+
+    #[test]
+    fn syntactically_equal_type() {
+        let context1 = [];
+        let source1 = TYPE;
+
+        let tokens1 = tokenize(None, source1).unwrap();
+        let term1 = parse(None, source1, &tokens1[..], &context1[..]).unwrap();
+
+        let context2 = [];
+        let source2 = TYPE;
+
+        let tokens2 = tokenize(None, source2).unwrap();
+        let term2 = parse(None, source2, &tokens2[..], &context2[..]).unwrap();
+
+        assert_eq!(syntactically_equal(&term1, &term2), true);
+    }
 
     #[test]
     fn syntactically_equal_alpha() {

--- a/src/term.rs
+++ b/src/term.rs
@@ -1,3 +1,4 @@
+use crate::token::TYPE;
 use std::{
     fmt::{Display, Formatter, Result},
     rc::Rc,
@@ -15,6 +16,9 @@ pub struct Term<'a> {
 // Each term has a "variant" describing what kind of term it is.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Variant<'a> {
+    // This is the type of all types, including itself.
+    Type,
+
     // A variable is a placeholder bound by a lambda or a pi type. The integer is the De Bruijn
     // index for the variable.
     Variable(&'a str, usize),
@@ -48,6 +52,7 @@ impl<'a> Display for Term<'a> {
 impl<'a> Display for Variant<'a> {
     fn fmt(&self, f: &mut Formatter) -> Result {
         match self {
+            Self::Type => write!(f, "{}", TYPE),
             Self::Variable(variable, _) => write!(f, "{}", variable),
             Self::Lambda(variable, domain, body) => {
                 write!(f, "({} : {}) => {}", variable, domain, body)

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,5 +1,8 @@
 use std::fmt::{Display, Formatter, Result};
 
+// This keyword is for the type of all types, including itself.
+pub const TYPE: &str = "type";
+
 // The first step of compilation is to split the source into a stream of tokens. This struct
 // represents a single token.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -16,6 +19,7 @@ pub enum Variant<'a> {
     RightParen,
     ThickArrow,
     ThinArrow,
+    Type,
     Identifier(&'a str),
 }
 
@@ -33,6 +37,7 @@ impl<'a> Display for Variant<'a> {
             Self::RightParen => write!(f, ")"),
             Self::ThickArrow => write!(f, "=>"),
             Self::ThinArrow => write!(f, "->"),
+            Self::Type => write!(f, "{}", TYPE),
             Self::Identifier(name) => write!(f, "{}", name),
         }
     }


### PR DESCRIPTION
Make `type` a keyword rather than a variable with weird special behavior.