### PR TITLE
Lift a constant to the top-level to avoid re-computing it

### DIFF
--- a/src/de_bruijn.rs
+++ b/src/de_bruijn.rs
@@ -116,7 +116,7 @@ mod tests {
             Term,
             Variant::{Application, Lambda, Pi, Type, Variable},
         },
-        token::TYPE,
+        token::TYPE_KEYWORD,
     };
     use std::rc::Rc;
 
@@ -125,7 +125,7 @@ mod tests {
         assert_eq!(
             *shift(
                 &Term {
-                    source_range: Some((0, TYPE.len())),
+                    source_range: Some((0, TYPE_KEYWORD.len())),
                     group: false,
                     variant: Type,
                 },
@@ -133,7 +133,7 @@ mod tests {
                 42,
             ),
             Term {
-                source_range: Some((0, TYPE.len())),
+                source_range: Some((0, TYPE_KEYWORD.len())),
                 group: false,
                 variant: Type,
             },
@@ -315,7 +315,7 @@ mod tests {
         assert_eq!(
             *open(
                 &Term {
-                    source_range: Some((0, TYPE.len())),
+                    source_range: Some((0, TYPE_KEYWORD.len())),
                     group: false,
                     variant: Type,
                 },
@@ -327,7 +327,7 @@ mod tests {
                 },
             ),
             Term {
-                source_range: Some((0, TYPE.len())),
+                source_range: Some((0, TYPE_KEYWORD.len())),
                 group: false,
                 variant: Type,
             },

--- a/src/equality.rs
+++ b/src/equality.rs
@@ -38,20 +38,20 @@ mod tests {
     use crate::{
         equality::{definitionally_equal, syntactically_equal},
         parser::parse,
-        token::TYPE,
+        token::TYPE_KEYWORD,
         tokenizer::tokenize,
     };
 
     #[test]
     fn syntactically_equal_type() {
         let context1 = [];
-        let source1 = TYPE;
+        let source1 = TYPE_KEYWORD;
 
         let tokens1 = tokenize(None, source1).unwrap();
         let term1 = parse(None, source1, &tokens1[..], &context1[..]).unwrap();
 
         let context2 = [];
-        let source2 = TYPE;
+        let source2 = TYPE_KEYWORD;
 
         let tokens2 = tokenize(None, source2).unwrap();
         let term2 = parse(None, source2, &tokens2[..], &context2[..]).unwrap();

--- a/src/normalizer.rs
+++ b/src/normalizer.rs
@@ -63,7 +63,7 @@ mod tests {
             Term,
             Variant::{Application, Lambda, Pi, Type, Variable},
         },
-        token::TYPE,
+        token::TYPE_KEYWORD,
         tokenizer::tokenize,
     };
     use std::rc::Rc;
@@ -71,7 +71,7 @@ mod tests {
     #[test]
     fn normalize_type() {
         let context = [];
-        let source = TYPE;
+        let source = TYPE_KEYWORD;
 
         let tokens = tokenize(None, source).unwrap();
         let term = parse(None, source, &tokens[..], &context[..]).unwrap();
@@ -79,7 +79,7 @@ mod tests {
         assert_eq!(
             *normalize(&term),
             Term {
-                source_range: Some((0, TYPE.len())),
+                source_range: Some((0, TYPE_KEYWORD.len())),
                 group: false,
                 variant: Type,
             },

--- a/src/term.rs
+++ b/src/term.rs
@@ -1,4 +1,4 @@
-use crate::token::TYPE;
+use crate::token::TYPE_KEYWORD;
 use std::{
     fmt::{Display, Formatter, Result},
     rc::Rc,
@@ -52,7 +52,7 @@ impl<'a> Display for Term<'a> {
 impl<'a> Display for Variant<'a> {
     fn fmt(&self, f: &mut Formatter) -> Result {
         match self {
-            Self::Type => write!(f, "{}", TYPE),
+            Self::Type => write!(f, "{}", TYPE_KEYWORD),
             Self::Variable(variable, _) => write!(f, "{}", variable),
             Self::Lambda(variable, domain, body) => {
                 write!(f, "({} : {}) => {}", variable, domain, body)
@@ -64,3 +64,10 @@ impl<'a> Display for Variant<'a> {
         }
     }
 }
+
+// Construct the type of all types once here rather than constructing it many times later.
+pub const TYPE_TERM: Term = Term {
+    source_range: None,
+    group: false,
+    variant: Variant::Type,
+};

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,7 +1,7 @@
 use std::fmt::{Display, Formatter, Result};
 
 // This keyword is for the type of all types, including itself.
-pub const TYPE: &str = "type";
+pub const TYPE_KEYWORD: &str = "type";
 
 // The first step of compilation is to split the source into a stream of tokens. This struct
 // represents a single token.
@@ -37,7 +37,7 @@ impl<'a> Display for Variant<'a> {
             Self::RightParen => write!(f, ")"),
             Self::ThickArrow => write!(f, "=>"),
             Self::ThinArrow => write!(f, "->"),
-            Self::Type => write!(f, "{}", TYPE),
+            Self::Type => write!(f, "{}", TYPE_KEYWORD),
             Self::Identifier(name) => write!(f, "{}", name),
         }
     }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::{throw, Error},
     format::CodeStr,
-    token::{Token, Variant, TYPE},
+    token::{Token, Variant, TYPE_KEYWORD},
 };
 use std::path::Path;
 
@@ -98,7 +98,7 @@ pub fn tokenize<'a>(
                     }
                 }
 
-                if &source_contents[i..end] == TYPE {
+                if &source_contents[i..end] == TYPE_KEYWORD {
                     tokens.push(Token {
                         source_range: (i, end),
                         variant: Variant::Type,
@@ -146,7 +146,7 @@ pub fn tokenize<'a>(
 mod tests {
     use crate::{
         assert_fails,
-        token::{Token, Variant, TYPE},
+        token::{Token, Variant, TYPE_KEYWORD},
         tokenizer::tokenize,
     };
 
@@ -218,9 +218,9 @@ mod tests {
     #[test]
     fn tokenize_type() {
         assert_eq!(
-            tokenize(None, TYPE).unwrap(),
+            tokenize(None, TYPE_KEYWORD).unwrap(),
             vec![Token {
-                source_range: (0, TYPE.len()),
+                source_range: (0, TYPE_KEYWORD.len()),
                 variant: Variant::Type,
             }],
         );


### PR DESCRIPTION
Lift a constant to the top-level to avoid re-computing it.