### PR TITLE
Make `normalize` take a context and add support for variables to have definitions in the context

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -113,13 +113,13 @@ fn run(source_path: &Path) -> Result<(), Error> {
     println!("# Original term:\n\n{}\n", term);
 
     // Print the normal form.
-    println!("# Normal form:\n\n{}\n", normalize(&term));
+    println!("# Normal form:\n\n{}\n", normalize(&term, &mut vec![]));
 
     // Type check the AST.
     let term_type = type_check(Some(source_path), &source_contents, &term, &mut vec![])?;
 
     // Normalize and print the type.
-    println!("# Type:\n\n{}", normalize(&term_type));
+    println!("# Type:\n\n{}", term_type);
 
     // If we made it this far, nothing went wrong.
     Ok(())

--- a/src/type_checker.rs
+++ b/src/type_checker.rs
@@ -13,199 +13,204 @@ use crate::{
 use std::{path::Path, rc::Rc};
 
 // This is the top-level type checking function. Invariants:
-// - The types of the variables in the context are normalized.
+// - The types and definitions of the variables in the context are normalized.
 // - The type returned by this function is normalized.
+// - When this function is finished, the context is left unmodified.
 #[allow(clippy::too_many_lines)]
 pub fn type_check<'a>(
     source_path: Option<&'a Path>,
     source_contents: &'a str,
     term: &Term<'a>,
-    context: &mut Vec<Rc<Term<'a>>>,
+    context: &mut Vec<(Rc<Term<'a>>, Option<Rc<Term<'a>>>)>, // [(type, definition)]
 ) -> Result<Rc<Term<'a>>, Error> {
     // The type checking rules are syntax-directed, so here we pattern match on the syntax.
-    Ok(normalize(&*match &term.variant {
-        Type => Rc::new(TYPE_TERM),
-        Variable(_, index) => {
-            // Look up the type in the context, and shift it such that it's valid in the
-            // current context.
-            shift(&*context[context.len() - 1 - *index], 0, *index + 1)
-        }
-        Lambda(variable, domain, body) => {
-            // Infer the type of the domain.
-            let domain_type = type_check(source_path, source_contents, &**domain, context)?;
-
-            // Check that the type of the domain is the type of all types.
-            if !syntactically_equal(&*domain_type, &TYPE_TERM) {
-                return Err(if let Some(source_range) = domain.source_range {
-                    throw(
-                        &format!(
-                            "This domain has type {} when {} was expected.",
-                            domain_type.to_string().code_str(),
-                            TYPE_TERM.to_string().code_str(),
-                        ),
-                        source_path,
-                        source_contents,
-                        source_range,
-                    )
-                } else {
-                    Error {
-                        message: format!(
-                            "Found domain of type {} when {} was expected.",
-                            domain_type.to_string().code_str(),
-                            TYPE_TERM.to_string().code_str(),
-                        ),
-                        reason: None,
-                    }
-                });
+    Ok(normalize(
+        &*match &term.variant {
+            Type => Rc::new(TYPE_TERM),
+            Variable(_, index) => {
+                // Look up the type in the context, and shift it such that it's valid in the
+                // current context.
+                shift(&*context[context.len() - 1 - *index].0, 0, *index + 1)
             }
+            Lambda(variable, domain, body) => {
+                // Infer the type of the domain.
+                let domain_type = type_check(source_path, source_contents, &**domain, context)?;
 
-            // Temporarily add the variable's type to the context for the purpose of inferring the
-            // codomain.
-            context.push(domain.clone());
+                // Check that the type of the domain is the type of all types.
+                if !syntactically_equal(&*domain_type, &TYPE_TERM) {
+                    return Err(if let Some(source_range) = domain.source_range {
+                        throw(
+                            &format!(
+                                "This domain has type {} when {} was expected.",
+                                domain_type.to_string().code_str(),
+                                TYPE_TERM.to_string().code_str(),
+                            ),
+                            source_path,
+                            source_contents,
+                            source_range,
+                        )
+                    } else {
+                        Error {
+                            message: format!(
+                                "Found domain of type {} when {} was expected.",
+                                domain_type.to_string().code_str(),
+                                TYPE_TERM.to_string().code_str(),
+                            ),
+                            reason: None,
+                        }
+                    });
+                }
 
-            // Infer the codomain.
-            let codomain = type_check(source_path, source_contents, &**body, context)?;
+                // Temporarily add the variable's type to the context for the purpose of inferring the
+                // codomain.
+                context.push((domain.clone(), None));
 
-            // Restore the context.
-            context.pop();
+                // Infer the codomain.
+                let codomain = type_check(source_path, source_contents, &**body, context)?;
 
-            // Construct and return the pi type.
-            Rc::new(Term {
-                source_range: term.source_range,
-                group: false,
-                variant: Pi(variable, domain.clone(), codomain),
-            })
-        }
-        Pi(_, domain, codomain) => {
-            // Infer the type of the domain.
-            let domain_type = type_check(source_path, source_contents, &**domain, context)?;
+                // Restore the context.
+                context.pop();
 
-            // Check that the type of the domain is the type of all types.
-            if !syntactically_equal(&*domain_type, &TYPE_TERM) {
-                return Err(if let Some(source_range) = domain.source_range {
-                    throw(
-                        &format!(
-                            "This domain has type {} when {} was expected.",
-                            domain_type.to_string().code_str(),
-                            TYPE_TERM.to_string().code_str(),
-                        ),
-                        source_path,
-                        source_contents,
-                        source_range,
-                    )
-                } else {
-                    Error {
-                        message: format!(
-                            "Found domain of type {} when {} was expected.",
-                            domain_type.to_string().code_str(),
-                            TYPE_TERM.to_string().code_str(),
-                        ),
-                        reason: None,
-                    }
-                });
+                // Construct and return the pi type.
+                Rc::new(Term {
+                    source_range: term.source_range,
+                    group: false,
+                    variant: Pi(variable, domain.clone(), codomain),
+                })
             }
+            Pi(_, domain, codomain) => {
+                // Infer the type of the domain.
+                let domain_type = type_check(source_path, source_contents, &**domain, context)?;
 
-            // Temporarily add the variable's type to the context for the purpose of inferring the
-            // type of the codomain.
-            context.push(domain.clone());
+                // Check that the type of the domain is the type of all types.
+                if !syntactically_equal(&*domain_type, &TYPE_TERM) {
+                    return Err(if let Some(source_range) = domain.source_range {
+                        throw(
+                            &format!(
+                                "This domain has type {} when {} was expected.",
+                                domain_type.to_string().code_str(),
+                                TYPE_TERM.to_string().code_str(),
+                            ),
+                            source_path,
+                            source_contents,
+                            source_range,
+                        )
+                    } else {
+                        Error {
+                            message: format!(
+                                "Found domain of type {} when {} was expected.",
+                                domain_type.to_string().code_str(),
+                                TYPE_TERM.to_string().code_str(),
+                            ),
+                            reason: None,
+                        }
+                    });
+                }
 
-            // Infer the type of the codomain.
-            let codomain_type = type_check(source_path, source_contents, &**codomain, context)?;
+                // Temporarily add the variable's type to the context for the purpose of inferring the
+                // type of the codomain.
+                context.push((domain.clone(), None));
 
-            // Restore the context.
-            context.pop();
+                // Infer the type of the codomain.
+                let codomain_type = type_check(source_path, source_contents, &**codomain, context)?;
 
-            // Check that the type of the codomain is the type of all types.
-            if !syntactically_equal(&*codomain_type, &TYPE_TERM) {
-                return Err(if let Some(source_range) = codomain.source_range {
-                    throw(
-                        &format!(
-                            "This codomain has type {} when {} was expected.",
-                            codomain_type.to_string().code_str(),
-                            TYPE_TERM.to_string().code_str(),
-                        ),
-                        source_path,
-                        source_contents,
-                        source_range,
-                    )
-                } else {
-                    Error {
-                        message: format!(
-                            "Found codomain of type {} when {} was expected.",
-                            codomain_type.to_string().code_str(),
-                            TYPE_TERM.to_string().code_str(),
-                        ),
-                        reason: None,
-                    }
-                });
+                // Restore the context.
+                context.pop();
+
+                // Check that the type of the codomain is the type of all types.
+                if !syntactically_equal(&*codomain_type, &TYPE_TERM) {
+                    return Err(if let Some(source_range) = codomain.source_range {
+                        throw(
+                            &format!(
+                                "This codomain has type {} when {} was expected.",
+                                codomain_type.to_string().code_str(),
+                                TYPE_TERM.to_string().code_str(),
+                            ),
+                            source_path,
+                            source_contents,
+                            source_range,
+                        )
+                    } else {
+                        Error {
+                            message: format!(
+                                "Found codomain of type {} when {} was expected.",
+                                codomain_type.to_string().code_str(),
+                                TYPE_TERM.to_string().code_str(),
+                            ),
+                            reason: None,
+                        }
+                    });
+                }
+
+                // The type of a pi type is the type of all types.
+                Rc::new(TYPE_TERM)
             }
+            Application(applicand, argument) => {
+                // Infer the type of the applicand.
+                let applicand_type =
+                    type_check(source_path, source_contents, &**applicand, context)?;
 
-            // The type of a pi type is the type of all types.
-            Rc::new(TYPE_TERM)
-        }
-        Application(applicand, argument) => {
-            // Infer the type of the applicand.
-            let applicand_type = type_check(source_path, source_contents, &**applicand, context)?;
-
-            // Make sure the type of the applicand is a pi type.
-            let (domain, codomain) = if let Pi(_, domain, codomain) = &applicand_type.variant {
-                (domain, codomain)
-            } else {
-                return Err(if let Some(source_range) = applicand.source_range {
-                    throw(
-                        &format!(
-                            "This has type {} when a pi type was expected.",
-                            applicand_type.to_string().code_str(),
-                        ),
-                        source_path,
-                        source_contents,
-                        source_range,
-                    )
+                // Make sure the type of the applicand is a pi type.
+                let (domain, codomain) = if let Pi(_, domain, codomain) = &applicand_type.variant {
+                    (domain, codomain)
                 } else {
-                    Error {
-                        message: format!(
-                            "Applicand {} has type {} when a pi type was expected.",
-                            applicand.to_string().code_str(),
-                            applicand_type.to_string().code_str(),
-                        ),
-                        reason: None,
-                    }
-                });
-            };
+                    return Err(if let Some(source_range) = applicand.source_range {
+                        throw(
+                            &format!(
+                                "This has type {} when a pi type was expected.",
+                                applicand_type.to_string().code_str(),
+                            ),
+                            source_path,
+                            source_contents,
+                            source_range,
+                        )
+                    } else {
+                        Error {
+                            message: format!(
+                                "Applicand {} has type {} when a pi type was expected.",
+                                applicand.to_string().code_str(),
+                                applicand_type.to_string().code_str(),
+                            ),
+                            reason: None,
+                        }
+                    });
+                };
 
-            // Infer the type of the argument.
-            let argument_type = type_check(source_path, source_contents, &**argument, context)?;
+                // Infer the type of the argument.
+                let argument_type = type_check(source_path, source_contents, &**argument, context)?;
 
-            // Check that the argument type equals the domain.
-            if !syntactically_equal(&*argument_type, &**domain) {
-                return Err(if let Some(source_range) = argument.source_range {
-                    throw(
-                        &format!(
-                            "This has type {} when {} was expected.",
-                            argument_type.to_string().code_str(),
-                            domain.to_string().code_str(),
-                        ),
-                        source_path,
-                        source_contents,
-                        source_range,
-                    )
-                } else {
-                    Error {
-                        message: format!(
-                            "Argument {} has type {} when {} was expected.",
-                            argument.to_string().code_str(),
-                            argument_type.to_string().code_str(),
-                            domain.to_string().code_str(),
-                        ),
-                        reason: None,
-                    }
-                });
+                // Check that the argument type equals the domain.
+                if !syntactically_equal(&*argument_type, &**domain) {
+                    return Err(if let Some(source_range) = argument.source_range {
+                        throw(
+                            &format!(
+                                "This has type {} when {} was expected.",
+                                argument_type.to_string().code_str(),
+                                domain.to_string().code_str(),
+                            ),
+                            source_path,
+                            source_contents,
+                            source_range,
+                        )
+                    } else {
+                        Error {
+                            message: format!(
+                                "Argument {} has type {} when {} was expected.",
+                                argument.to_string().code_str(),
+                                argument_type.to_string().code_str(),
+                                domain.to_string().code_str(),
+                            ),
+                            reason: None,
+                        }
+                    });
+                }
+
+                // Construct and return the codomain specialized to the argument.
+                open(&**codomain, 0, &**argument)
             }
-
-            // Construct and return the codomain specialized to the argument.
-            open(&**codomain, 0, &**argument)
-        }
-    }))
+        },
+        context,
+    ))
 }
 
 #[cfg(test)]
@@ -245,16 +250,22 @@ mod tests {
     fn type_check_variable() {
         let parsing_context = ["a", "x"];
         let mut typing_context = vec![
-            Rc::new(Term {
-                source_range: None,
-                group: false,
-                variant: Type,
-            }),
-            Rc::new(Term {
-                source_range: None,
-                group: false,
-                variant: Variable("a", 0),
-            }),
+            (
+                Rc::new(Term {
+                    source_range: None,
+                    group: false,
+                    variant: Type,
+                }),
+                None,
+            ),
+            (
+                Rc::new(Term {
+                    source_range: None,
+                    group: false,
+                    variant: Variable("a", 0),
+                }),
+                None,
+            ),
         ];
         let term_source = "x";
         let type_source = "a";
@@ -273,11 +284,14 @@ mod tests {
     #[test]
     fn type_check_lambda() {
         let parsing_context = ["a"];
-        let mut typing_context = vec![Rc::new(Term {
-            source_range: None,
-            group: false,
-            variant: Type,
-        })];
+        let mut typing_context = vec![(
+            Rc::new(Term {
+                source_range: None,
+                group: false,
+                variant: Type,
+            }),
+            None,
+        )];
         let term_source = "(x : a) => x";
         let type_source = "(x : a) -> a";
 
@@ -295,11 +309,14 @@ mod tests {
     #[test]
     fn type_check_pi() {
         let parsing_context = ["a"];
-        let mut typing_context = vec![Rc::new(Term {
-            source_range: None,
-            group: false,
-            variant: Type,
-        })];
+        let mut typing_context = vec![(
+            Rc::new(Term {
+                source_range: None,
+                group: false,
+                variant: Type,
+            }),
+            None,
+        )];
         let term_source = "(x : a) -> a";
         let type_source = "type";
 
@@ -318,16 +335,22 @@ mod tests {
     fn type_check_application() {
         let parsing_context = ["a", "y"];
         let mut typing_context = vec![
-            Rc::new(Term {
-                source_range: None,
-                group: false,
-                variant: Type,
-            }),
-            Rc::new(Term {
-                source_range: None,
-                group: false,
-                variant: Variable("a", 0),
-            }),
+            (
+                Rc::new(Term {
+                    source_range: None,
+                    group: false,
+                    variant: Type,
+                }),
+                None,
+            ),
+            (
+                Rc::new(Term {
+                    source_range: None,
+                    group: false,
+                    variant: Variable("a", 0),
+                }),
+                None,
+            ),
         ];
         let term_source = "((x : a) => x) y";
         let type_source = "a";
@@ -347,21 +370,30 @@ mod tests {
     fn type_check_bad_application() {
         let parsing_context = ["a", "b", "y"];
         let mut typing_context = vec![
-            Rc::new(Term {
-                source_range: None,
-                group: false,
-                variant: Type,
-            }),
-            Rc::new(Term {
-                source_range: None,
-                group: false,
-                variant: Type,
-            }),
-            Rc::new(Term {
-                source_range: None,
-                group: false,
-                variant: Variable("b", 0),
-            }),
+            (
+                Rc::new(Term {
+                    source_range: None,
+                    group: false,
+                    variant: Type,
+                }),
+                None,
+            ),
+            (
+                Rc::new(Term {
+                    source_range: None,
+                    group: false,
+                    variant: Type,
+                }),
+                None,
+            ),
+            (
+                Rc::new(Term {
+                    source_range: None,
+                    group: false,
+                    variant: Variable("b", 0),
+                }),
+                None,
+            ),
         ];
         let term_source = "((x : a) => x) y";
 
@@ -378,16 +410,22 @@ mod tests {
     fn type_check_dependent_apply() {
         let parsing_context = ["int", "y"];
         let mut typing_context = vec![
-            Rc::new(Term {
-                source_range: None,
-                group: false,
-                variant: Type,
-            }),
-            Rc::new(Term {
-                source_range: None,
-                group: false,
-                variant: Variable("int", 0),
-            }),
+            (
+                Rc::new(Term {
+                    source_range: None,
+                    group: false,
+                    variant: Type,
+                }),
+                None,
+            ),
+            (
+                Rc::new(Term {
+                    source_range: None,
+                    group: false,
+                    variant: Variable("int", 0),
+                }),
+                None,
+            ),
         ];
         let term_source = "
           ((a : type) => (P: (x : a) -> type) => (f : (x : a) -> P x) => (x : a) => f x)


### PR DESCRIPTION
Make `normalize` take a context and add support for variables to have definitions in the context. This is in preparation for adding `let` support.