### PR TITLE
Implement lazy convertibility

### DIFF
--- a/src/equality.rs
+++ b/src/equality.rs
@@ -3,9 +3,11 @@ use crate::term::{
     Variant::{Application, Lambda, Let, Pi, Type, Variable},
 };
 
-// Check if two terms are equal up to alpha renaming.
+// Check if two terms are equal up to alpha conversion.
 pub fn syntactically_equal<'a>(term1: &Term<'a>, term2: &Term<'a>) -> bool {
-    // Recursively check sub-terms.
+    // Due to the catch-all case at the bottom of this `match`, the compiler will not complain if a
+    // new syntactic form is added and this `match` is not updated. Be sure to update it when
+    // adding new syntactic forms!
     match (&term1.variant, &term2.variant) {
         (Type, Type) => true,
         (Variable(_, index1), Variable(_, index2)) => index1 == index2,

--- a/src/equality.rs
+++ b/src/equality.rs
@@ -1,7 +1,11 @@
-use crate::term::{
-    Term,
-    Variant::{Application, Lambda, Let, Pi, Type, Variable},
+use crate::{
+    normalizer::normalize_weak_head,
+    term::{
+        Term,
+        Variant::{Application, Lambda, Let, Pi, Type, Variable},
+    },
 };
+use std::rc::Rc;
 
 // Check if two terms are equal up to alpha conversion. Type annotations are not checked.
 pub fn syntactically_equal<'a>(term1: &Term<'a>, term2: &Term<'a>) -> bool {
@@ -28,264 +32,590 @@ pub fn syntactically_equal<'a>(term1: &Term<'a>, term2: &Term<'a>) -> bool {
     }
 }
 
+// Check if two terms are convertible up to beta normalization. Type annotations are not checked.
+pub fn definitionally_equal<'a>(
+    term1: Rc<Term<'a>>,
+    term2: Rc<Term<'a>>,
+    normalization_context: &mut Vec<Option<Rc<Term<'a>>>>,
+) -> bool {
+    // The two terms might not have normal forms, but if they are syntactically equal then we can
+    // still consider them definitionally equal. So we check for that first.
+    if syntactically_equal(&*term1, &*term2) {
+        return true;
+    }
+
+    // Reduce both terms to weak head normal form and recursively check for convertibility. Note
+    // that there is no case for lets because lets are never in weak head normal form. Due to the
+    // catch-all case at the bottom of this `match`, the compiler will not complain if a new
+    // syntactic form is added and this `match` is not updated. Be sure to update it when adding
+    // new syntactic forms!
+    match (
+        &normalize_weak_head(term1, normalization_context).variant,
+        &normalize_weak_head(term2, normalization_context).variant,
+    ) {
+        (Type, Type) => true,
+        (Variable(_, index1), Variable(_, index2)) => index1 == index2,
+        (Lambda(_, _, body1), Lambda(_, _, body2)) => {
+            // Temporarily add the variable to the context for the purpose of normalizing the body.
+            normalization_context.push(None);
+
+            // Check if the bodies are definitionally equal.
+            let bodies_definitionally_equal =
+                definitionally_equal(body1.clone(), body2.clone(), normalization_context);
+
+            // Restore the context.
+            normalization_context.pop();
+
+            // Return the result.
+            bodies_definitionally_equal
+        }
+        (Pi(_, domain1, codomain1), Pi(_, domain2, codomain2)) => {
+            definitionally_equal(domain1.clone(), domain2.clone(), normalization_context) && {
+                // Temporarily add the variable to the context for the purpose of normalizing the body.
+                normalization_context.push(None);
+
+                // Check if the codomains are definitionally equal.
+                let codomains_definitionally_equal = definitionally_equal(
+                    codomain1.clone(),
+                    codomain2.clone(),
+                    normalization_context,
+                );
+
+                // Restore the context.
+                normalization_context.pop();
+
+                // Return the result.
+                codomains_definitionally_equal
+            }
+        }
+        (Application(applicand1, argument1), Application(applicand2, argument2)) => {
+            definitionally_equal(
+                applicand1.clone(),
+                applicand2.clone(),
+                normalization_context,
+            ) && definitionally_equal(argument1.clone(), argument2.clone(), normalization_context)
+        }
+        _ => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{
-        equality::syntactically_equal, parser::parse, token::TYPE_KEYWORD, tokenizer::tokenize,
+        equality::{definitionally_equal, syntactically_equal},
+        parser::parse,
+        token::TYPE_KEYWORD,
+        tokenizer::tokenize,
     };
+    use std::rc::Rc;
 
     #[test]
     fn syntactically_equal_type() {
-        let context1 = [];
+        let context = [];
+
         let source1 = TYPE_KEYWORD;
-
         let tokens1 = tokenize(None, source1).unwrap();
-        let term1 = parse(None, source1, &tokens1[..], &context1[..]).unwrap();
+        let term1 = parse(None, source1, &tokens1[..], &context[..]).unwrap();
 
-        let context2 = [];
         let source2 = TYPE_KEYWORD;
-
         let tokens2 = tokenize(None, source2).unwrap();
-        let term2 = parse(None, source2, &tokens2[..], &context2[..]).unwrap();
+        let term2 = parse(None, source2, &tokens2[..], &context[..]).unwrap();
 
         assert_eq!(syntactically_equal(&term1, &term2), true);
     }
 
     #[test]
-    fn syntactically_equal_alpha() {
-        let context1 = ["x"];
+    fn syntactically_equal_variable() {
+        let context = ["x"];
+
         let source1 = "x";
-
         let tokens1 = tokenize(None, source1).unwrap();
-        let term1 = parse(None, source1, &tokens1[..], &context1[..]).unwrap();
+        let term1 = parse(None, source1, &tokens1[..], &context[..]).unwrap();
 
-        let context2 = ["y"];
-        let source2 = "y";
-
+        let source2 = "x";
         let tokens2 = tokenize(None, source2).unwrap();
-        let term2 = parse(None, source2, &tokens2[..], &context2[..]).unwrap();
+        let term2 = parse(None, source2, &tokens2[..], &context[..]).unwrap();
 
         assert_eq!(syntactically_equal(&term1, &term2), true);
     }
 
     #[test]
     fn syntactically_inequal_variable() {
-        let context1 = ["x"];
+        let context = ["x", "y"];
+
         let source1 = "x";
-
         let tokens1 = tokenize(None, source1).unwrap();
-        let term1 = parse(None, source1, &tokens1[..], &context1[..]).unwrap();
+        let term1 = parse(None, source1, &tokens1[..], &context[..]).unwrap();
 
-        let context2 = ["x", "y"];
-        let source2 = "x";
-
+        let source2 = "y";
         let tokens2 = tokenize(None, source2).unwrap();
-        let term2 = parse(None, source2, &tokens2[..], &context2[..]).unwrap();
+        let term2 = parse(None, source2, &tokens2[..], &context[..]).unwrap();
 
         assert_eq!(syntactically_equal(&term1, &term2), false);
     }
 
     #[test]
     fn syntactically_equal_lambda() {
-        let context1 = [];
+        let context = [];
+
         let source1 = "(x : type) => x";
-
         let tokens1 = tokenize(None, source1).unwrap();
-        let term1 = parse(None, source1, &tokens1[..], &context1[..]).unwrap();
+        let term1 = parse(None, source1, &tokens1[..], &context[..]).unwrap();
 
-        let context2 = [];
         let source2 = "(x : type) => x";
-
         let tokens2 = tokenize(None, source2).unwrap();
-        let term2 = parse(None, source2, &tokens2[..], &context2[..]).unwrap();
+        let term2 = parse(None, source2, &tokens2[..], &context[..]).unwrap();
 
         assert_eq!(syntactically_equal(&term1, &term2), true);
     }
 
     #[test]
     fn syntactically_equal_lambda_inequal_domain() {
-        let context1 = [];
+        let context = [];
+
         let source1 = "(x : type) => x";
-
         let tokens1 = tokenize(None, source1).unwrap();
-        let term1 = parse(None, source1, &tokens1[..], &context1[..]).unwrap();
+        let term1 = parse(None, source1, &tokens1[..], &context[..]).unwrap();
 
-        let context2 = [];
         let source2 = "(x : (type type)) => x";
-
         let tokens2 = tokenize(None, source2).unwrap();
-        let term2 = parse(None, source2, &tokens2[..], &context2[..]).unwrap();
+        let term2 = parse(None, source2, &tokens2[..], &context[..]).unwrap();
 
         assert_eq!(syntactically_equal(&term1, &term2), true);
     }
 
     #[test]
     fn syntactically_inequal_lambda_body() {
-        let context1 = [];
+        let context = [];
+
         let source1 = "(x : type) => x";
-
         let tokens1 = tokenize(None, source1).unwrap();
-        let term1 = parse(None, source1, &tokens1[..], &context1[..]).unwrap();
+        let term1 = parse(None, source1, &tokens1[..], &context[..]).unwrap();
 
-        let context2 = [];
         let source2 = "(x : type) => type";
-
         let tokens2 = tokenize(None, source2).unwrap();
-        let term2 = parse(None, source2, &tokens2[..], &context2[..]).unwrap();
+        let term2 = parse(None, source2, &tokens2[..], &context[..]).unwrap();
 
         assert_eq!(syntactically_equal(&term1, &term2), false);
     }
 
     #[test]
     fn syntactically_equal_pi() {
-        let context1 = [];
+        let context = [];
+
         let source1 = "(x : type) -> x";
-
         let tokens1 = tokenize(None, source1).unwrap();
-        let term1 = parse(None, source1, &tokens1[..], &context1[..]).unwrap();
+        let term1 = parse(None, source1, &tokens1[..], &context[..]).unwrap();
 
-        let context2 = [];
         let source2 = "(x : type) -> x";
-
         let tokens2 = tokenize(None, source2).unwrap();
-        let term2 = parse(None, source2, &tokens2[..], &context2[..]).unwrap();
+        let term2 = parse(None, source2, &tokens2[..], &context[..]).unwrap();
 
         assert_eq!(syntactically_equal(&term1, &term2), true);
     }
 
     #[test]
     fn syntactically_inequal_pi_domain() {
-        let context1 = [];
+        let context = [];
+
         let source1 = "(x : type) -> x";
-
         let tokens1 = tokenize(None, source1).unwrap();
-        let term1 = parse(None, source1, &tokens1[..], &context1[..]).unwrap();
+        let term1 = parse(None, source1, &tokens1[..], &context[..]).unwrap();
 
-        let context2 = [];
         let source2 = "(x : (type type)) -> x";
-
         let tokens2 = tokenize(None, source2).unwrap();
-        let term2 = parse(None, source2, &tokens2[..], &context2[..]).unwrap();
+        let term2 = parse(None, source2, &tokens2[..], &context[..]).unwrap();
 
         assert_eq!(syntactically_equal(&term1, &term2), false);
     }
 
     #[test]
     fn syntactically_inequal_pi_codomain() {
-        let context1 = [];
+        let context = [];
+
         let source1 = "(x : type) -> x";
-
         let tokens1 = tokenize(None, source1).unwrap();
-        let term1 = parse(None, source1, &tokens1[..], &context1[..]).unwrap();
+        let term1 = parse(None, source1, &tokens1[..], &context[..]).unwrap();
 
-        let context2 = [];
         let source2 = "(x : type) -> type";
-
         let tokens2 = tokenize(None, source2).unwrap();
-        let term2 = parse(None, source2, &tokens2[..], &context2[..]).unwrap();
+        let term2 = parse(None, source2, &tokens2[..], &context[..]).unwrap();
 
         assert_eq!(syntactically_equal(&term1, &term2), false);
     }
 
     #[test]
     fn syntactically_equal_application() {
-        let context1 = ["f", "x"];
+        let context = ["f", "x"];
+
         let source1 = "f x";
-
         let tokens1 = tokenize(None, source1).unwrap();
-        let term1 = parse(None, source1, &tokens1[..], &context1[..]).unwrap();
+        let term1 = parse(None, source1, &tokens1[..], &context[..]).unwrap();
 
-        let context2 = ["f", "x"];
         let source2 = "f x";
-
         let tokens2 = tokenize(None, source2).unwrap();
-        let term2 = parse(None, source2, &tokens2[..], &context2[..]).unwrap();
+        let term2 = parse(None, source2, &tokens2[..], &context[..]).unwrap();
 
         assert_eq!(syntactically_equal(&term1, &term2), true);
     }
 
     #[test]
     fn syntactically_inequal_application_applicand() {
-        let context1 = ["f", "x"];
+        let context = ["f", "x"];
+
         let source1 = "f x";
-
         let tokens1 = tokenize(None, source1).unwrap();
-        let term1 = parse(None, source1, &tokens1[..], &context1[..]).unwrap();
+        let term1 = parse(None, source1, &tokens1[..], &context[..]).unwrap();
 
-        let context2 = ["f", "x"];
         let source2 = "x x";
-
         let tokens2 = tokenize(None, source2).unwrap();
-        let term2 = parse(None, source2, &tokens2[..], &context2[..]).unwrap();
+        let term2 = parse(None, source2, &tokens2[..], &context[..]).unwrap();
 
         assert_eq!(syntactically_equal(&term1, &term2), false);
     }
 
     #[test]
     fn syntactically_inequal_application_argument() {
-        let context1 = ["f", "x"];
+        let context = ["f", "x"];
+
         let source1 = "f x";
-
         let tokens1 = tokenize(None, source1).unwrap();
-        let term1 = parse(None, source1, &tokens1[..], &context1[..]).unwrap();
+        let term1 = parse(None, source1, &tokens1[..], &context[..]).unwrap();
 
-        let context2 = ["f", "x"];
         let source2 = "f f";
-
         let tokens2 = tokenize(None, source2).unwrap();
-        let term2 = parse(None, source2, &tokens2[..], &context2[..]).unwrap();
+        let term2 = parse(None, source2, &tokens2[..], &context[..]).unwrap();
 
         assert_eq!(syntactically_equal(&term1, &term2), false);
     }
 
     #[test]
     fn syntactically_equal_let() {
-        let context1 = [];
+        let context = [];
+
         let source1 = "x = type; x";
-
         let tokens1 = tokenize(None, source1).unwrap();
-        let term1 = parse(None, source1, &tokens1[..], &context1[..]).unwrap();
+        let term1 = parse(None, source1, &tokens1[..], &context[..]).unwrap();
 
-        let context2 = [];
         let source2 = "x = type; x";
-
         let tokens2 = tokenize(None, source2).unwrap();
-        let term2 = parse(None, source2, &tokens2[..], &context2[..]).unwrap();
+        let term2 = parse(None, source2, &tokens2[..], &context[..]).unwrap();
 
         assert_eq!(syntactically_equal(&term1, &term2), true);
     }
 
     #[test]
     fn syntactically_inequal_let_definition() {
-        let context1 = [];
+        let context = [];
+
         let source1 = "x = type; x";
-
         let tokens1 = tokenize(None, source1).unwrap();
-        let term1 = parse(None, source1, &tokens1[..], &context1[..]).unwrap();
+        let term1 = parse(None, source1, &tokens1[..], &context[..]).unwrap();
 
-        let context2 = [];
         let source2 = "x = type type; x";
-
         let tokens2 = tokenize(None, source2).unwrap();
-        let term2 = parse(None, source2, &tokens2[..], &context2[..]).unwrap();
+        let term2 = parse(None, source2, &tokens2[..], &context[..]).unwrap();
 
         assert_eq!(syntactically_equal(&term1, &term2), false);
     }
 
     #[test]
     fn syntactically_inequal_let_body() {
-        let context1 = [];
+        let context = [];
+
         let source1 = "x = type type; x";
-
         let tokens1 = tokenize(None, source1).unwrap();
-        let term1 = parse(None, source1, &tokens1[..], &context1[..]).unwrap();
+        let term1 = parse(None, source1, &tokens1[..], &context[..]).unwrap();
 
-        let context2 = [];
         let source2 = "x = type; type";
-
         let tokens2 = tokenize(None, source2).unwrap();
-        let term2 = parse(None, source2, &tokens2[..], &context2[..]).unwrap();
+        let term2 = parse(None, source2, &tokens2[..], &context[..]).unwrap();
 
         assert_eq!(syntactically_equal(&term1, &term2), false);
+    }
+
+    #[test]
+    fn definitionally_equal_type() {
+        let context = [];
+        let mut normalization_context = vec![];
+
+        let source1 = TYPE_KEYWORD;
+        let tokens1 = tokenize(None, source1).unwrap();
+        let term1 = parse(None, source1, &tokens1[..], &context[..]).unwrap();
+
+        let source2 = TYPE_KEYWORD;
+        let tokens2 = tokenize(None, source2).unwrap();
+        let term2 = parse(None, source2, &tokens2[..], &context[..]).unwrap();
+
+        assert_eq!(
+            definitionally_equal(Rc::new(term1), Rc::new(term2), &mut normalization_context),
+            true
+        );
+    }
+
+    #[test]
+    fn definitionally_equal_variable() {
+        let context = ["x"];
+        let mut normalization_context = vec![None, None];
+
+        let source1 = "x";
+        let tokens1 = tokenize(None, source1).unwrap();
+        let term1 = parse(None, source1, &tokens1[..], &context[..]).unwrap();
+
+        let source2 = "x";
+        let tokens2 = tokenize(None, source2).unwrap();
+        let term2 = parse(None, source2, &tokens2[..], &context[..]).unwrap();
+
+        assert_eq!(
+            definitionally_equal(Rc::new(term1), Rc::new(term2), &mut normalization_context),
+            true
+        );
+    }
+
+    #[test]
+    fn definitionally_inequal_variable() {
+        let context = ["x", "y"];
+        let mut normalization_context = vec![None, None];
+
+        let source1 = "x";
+        let tokens1 = tokenize(None, source1).unwrap();
+        let term1 = parse(None, source1, &tokens1[..], &context[..]).unwrap();
+
+        let source2 = "y";
+        let tokens2 = tokenize(None, source2).unwrap();
+        let term2 = parse(None, source2, &tokens2[..], &context[..]).unwrap();
+
+        assert_eq!(
+            definitionally_equal(Rc::new(term1), Rc::new(term2), &mut normalization_context),
+            false
+        );
+    }
+
+    #[test]
+    fn definitionally_equal_lambda() {
+        let context = [];
+        let mut normalization_context = vec![];
+
+        let source1 = "(x : type) => x";
+        let tokens1 = tokenize(None, source1).unwrap();
+        let term1 = parse(None, source1, &tokens1[..], &context[..]).unwrap();
+
+        let source2 = "(x : type) => x";
+        let tokens2 = tokenize(None, source2).unwrap();
+        let term2 = parse(None, source2, &tokens2[..], &context[..]).unwrap();
+
+        assert_eq!(
+            definitionally_equal(Rc::new(term1), Rc::new(term2), &mut normalization_context),
+            true
+        );
+    }
+
+    #[test]
+    fn definitionally_equal_lambda_inequal_domain() {
+        let context = [];
+        let mut normalization_context = vec![];
+
+        let source1 = "(x : type) => x";
+        let tokens1 = tokenize(None, source1).unwrap();
+        let term1 = parse(None, source1, &tokens1[..], &context[..]).unwrap();
+
+        let source2 = "(x : (type type)) => x";
+        let tokens2 = tokenize(None, source2).unwrap();
+        let term2 = parse(None, source2, &tokens2[..], &context[..]).unwrap();
+
+        assert_eq!(
+            definitionally_equal(Rc::new(term1), Rc::new(term2), &mut normalization_context),
+            true
+        );
+    }
+
+    #[test]
+    fn definitionally_inequal_lambda_body() {
+        let context = [];
+        let mut normalization_context = vec![];
+
+        let source1 = "(x : type) => x";
+        let tokens1 = tokenize(None, source1).unwrap();
+        let term1 = parse(None, source1, &tokens1[..], &context[..]).unwrap();
+
+        let source2 = "(x : type) => type";
+        let tokens2 = tokenize(None, source2).unwrap();
+        let term2 = parse(None, source2, &tokens2[..], &context[..]).unwrap();
+
+        assert_eq!(
+            definitionally_equal(Rc::new(term1), Rc::new(term2), &mut normalization_context),
+            false
+        );
+    }
+
+    #[test]
+    fn definitionally_equal_pi() {
+        let context = [];
+        let mut normalization_context = vec![];
+
+        let source1 = "(x : type) -> x";
+        let tokens1 = tokenize(None, source1).unwrap();
+        let term1 = parse(None, source1, &tokens1[..], &context[..]).unwrap();
+
+        let source2 = "(x : type) -> x";
+        let tokens2 = tokenize(None, source2).unwrap();
+        let term2 = parse(None, source2, &tokens2[..], &context[..]).unwrap();
+
+        assert_eq!(
+            definitionally_equal(Rc::new(term1), Rc::new(term2), &mut normalization_context),
+            true
+        );
+    }
+
+    #[test]
+    fn definitionally_inequal_pi_domain() {
+        let context = [];
+        let mut normalization_context = vec![];
+
+        let source1 = "(x : type) -> x";
+        let tokens1 = tokenize(None, source1).unwrap();
+        let term1 = parse(None, source1, &tokens1[..], &context[..]).unwrap();
+
+        let source2 = "(x : (type type)) -> x";
+        let tokens2 = tokenize(None, source2).unwrap();
+        let term2 = parse(None, source2, &tokens2[..], &context[..]).unwrap();
+
+        assert_eq!(
+            definitionally_equal(Rc::new(term1), Rc::new(term2), &mut normalization_context),
+            false
+        );
+    }
+
+    #[test]
+    fn definitionally_inequal_pi_codomain() {
+        let context = [];
+        let mut normalization_context = vec![];
+
+        let source1 = "(x : type) -> x";
+        let tokens1 = tokenize(None, source1).unwrap();
+        let term1 = parse(None, source1, &tokens1[..], &context[..]).unwrap();
+
+        let source2 = "(x : type) -> type";
+        let tokens2 = tokenize(None, source2).unwrap();
+        let term2 = parse(None, source2, &tokens2[..], &context[..]).unwrap();
+
+        assert_eq!(
+            definitionally_equal(Rc::new(term1), Rc::new(term2), &mut normalization_context),
+            false
+        );
+    }
+
+    #[test]
+    fn definitionally_equal_application() {
+        let context = ["f", "x"];
+        let mut normalization_context = vec![None, None];
+
+        let source1 = "f x";
+        let tokens1 = tokenize(None, source1).unwrap();
+        let term1 = parse(None, source1, &tokens1[..], &context[..]).unwrap();
+
+        let source2 = "f x";
+        let tokens2 = tokenize(None, source2).unwrap();
+        let term2 = parse(None, source2, &tokens2[..], &context[..]).unwrap();
+
+        assert_eq!(
+            definitionally_equal(Rc::new(term1), Rc::new(term2), &mut normalization_context),
+            true
+        );
+    }
+
+    #[test]
+    fn definitionally_inequal_application_applicand() {
+        let context = ["f", "x"];
+        let mut normalization_context = vec![None, None];
+
+        let source1 = "f x";
+        let tokens1 = tokenize(None, source1).unwrap();
+        let term1 = parse(None, source1, &tokens1[..], &context[..]).unwrap();
+
+        let source2 = "x x";
+        let tokens2 = tokenize(None, source2).unwrap();
+        let term2 = parse(None, source2, &tokens2[..], &context[..]).unwrap();
+
+        assert_eq!(
+            definitionally_equal(Rc::new(term1), Rc::new(term2), &mut normalization_context),
+            false
+        );
+    }
+
+    #[test]
+    fn definitionally_inequal_application_argument() {
+        let context = ["f", "x"];
+        let mut normalization_context = vec![None, None];
+
+        let source1 = "f x";
+        let tokens1 = tokenize(None, source1).unwrap();
+        let term1 = parse(None, source1, &tokens1[..], &context[..]).unwrap();
+
+        let source2 = "f f";
+        let tokens2 = tokenize(None, source2).unwrap();
+        let term2 = parse(None, source2, &tokens2[..], &context[..]).unwrap();
+
+        assert_eq!(
+            definitionally_equal(Rc::new(term1), Rc::new(term2), &mut normalization_context),
+            false
+        );
+    }
+
+    #[test]
+    fn definitionally_equal_let() {
+        let context = [];
+        let mut normalization_context = vec![];
+
+        let source1 = "x = type; x";
+        let tokens1 = tokenize(None, source1).unwrap();
+        let term1 = parse(None, source1, &tokens1[..], &context[..]).unwrap();
+
+        let source2 = "x = type; x";
+        let tokens2 = tokenize(None, source2).unwrap();
+        let term2 = parse(None, source2, &tokens2[..], &context[..]).unwrap();
+
+        assert_eq!(
+            definitionally_equal(Rc::new(term1), Rc::new(term2), &mut normalization_context),
+            true
+        );
+    }
+
+    #[test]
+    fn definitionally_inequal_let_definition() {
+        let context = [];
+        let mut normalization_context = vec![];
+
+        let source1 = "x = type; x";
+        let tokens1 = tokenize(None, source1).unwrap();
+        let term1 = parse(None, source1, &tokens1[..], &context[..]).unwrap();
+
+        let source2 = "x = type type; x";
+        let tokens2 = tokenize(None, source2).unwrap();
+        let term2 = parse(None, source2, &tokens2[..], &context[..]).unwrap();
+
+        assert_eq!(
+            definitionally_equal(Rc::new(term1), Rc::new(term2), &mut normalization_context),
+            false
+        );
+    }
+
+    #[test]
+    fn definitionally_inequal_let_body() {
+        let context = [];
+        let mut normalization_context = vec![];
+
+        let source1 = "x = type type; x";
+        let tokens1 = tokenize(None, source1).unwrap();
+        let term1 = parse(None, source1, &tokens1[..], &context[..]).unwrap();
+
+        let source2 = "x = type; type";
+        let tokens2 = tokenize(None, source2).unwrap();
+        let term2 = parse(None, source2, &tokens2[..], &context[..]).unwrap();
+
+        assert_eq!(
+            definitionally_equal(Rc::new(term1), Rc::new(term2), &mut normalization_context),
+            false
+        );
     }
 }

--- a/src/equality.rs
+++ b/src/equality.rs
@@ -3,7 +3,7 @@ use crate::term::{
     Variant::{Application, Lambda, Let, Pi, Type, Variable},
 };
 
-// Check if two terms are equal up to alpha conversion.
+// Check if two terms are equal up to alpha conversion. Type annotations are not checked.
 pub fn syntactically_equal<'a>(term1: &Term<'a>, term2: &Term<'a>) -> bool {
     // Due to the catch-all case at the bottom of this `match`, the compiler will not complain if a
     // new syntactic form is added and this `match` is not updated. Be sure to update it when
@@ -11,9 +11,7 @@ pub fn syntactically_equal<'a>(term1: &Term<'a>, term2: &Term<'a>) -> bool {
     match (&term1.variant, &term2.variant) {
         (Type, Type) => true,
         (Variable(_, index1), Variable(_, index2)) => index1 == index2,
-        (Lambda(_, domain1, body1), Lambda(_, domain2, body2)) => {
-            syntactically_equal(&**domain1, &**domain2) && syntactically_equal(&**body1, &**body2)
-        }
+        (Lambda(_, _, body1), Lambda(_, _, body2)) => syntactically_equal(&**body1, &**body2),
         (Pi(_, domain1, codomain1), Pi(_, domain2, codomain2)) => {
             syntactically_equal(&**domain1, &**domain2)
                 && syntactically_equal(&**codomain1, &**codomain2)
@@ -105,7 +103,7 @@ mod tests {
     }
 
     #[test]
-    fn syntactically_inequal_lambda_domain() {
+    fn syntactically_equal_lambda_inequal_domain() {
         let context1 = [];
         let source1 = "(x : type) => x";
 
@@ -118,7 +116,7 @@ mod tests {
         let tokens2 = tokenize(None, source2).unwrap();
         let term2 = parse(None, source2, &tokens2[..], &context2[..]).unwrap();
 
-        assert_eq!(syntactically_equal(&term1, &term2), false);
+        assert_eq!(syntactically_equal(&term1, &term2), true);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ use clap::{
     AppSettings::{ColoredHelp, UnifiedHelpMessage, VersionlessSubcommands},
     Arg, Shell, SubCommand,
 };
-use std::{fs::read_to_string, io::stdout, path::Path, process::exit};
+use std::{fs::read_to_string, io::stdout, path::Path, process::exit, rc::Rc};
 
 // The program version
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -123,7 +123,7 @@ fn run(source_path: &Path) -> Result<(), Error> {
     println!("# Type:\n\n{}\n", term_type.to_string().code_str());
 
     // Print the normal form.
-    let normal_form = normalize_beta(&term, &mut normalization_context);
+    let normal_form = normalize_beta(Rc::new(term), &mut normalization_context);
     println!("# Normal form:\n\n{}", normal_form.to_string().code_str());
 
     // If we made it this far, nothing went wrong.

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ mod type_checker;
 use crate::{
     error::{lift, Error},
     format::CodeStr,
-    normalizer::normalize,
+    normalizer::normalize_beta,
     parser::parse,
     tokenizer::tokenize,
     type_checker::type_check,
@@ -123,7 +123,7 @@ fn run(source_path: &Path) -> Result<(), Error> {
     println!("# Type:\n\n{}\n", term_type.to_string().code_str());
 
     // Print the normal form.
-    let normal_form = normalize(&term, &mut normalization_context);
+    let normal_form = normalize_beta(&term, &mut normalization_context);
     println!("# Normal form:\n\n{}", normal_form.to_string().code_str());
 
     // If we made it this far, nothing went wrong.

--- a/src/normalizer.rs
+++ b/src/normalizer.rs
@@ -15,8 +15,8 @@ pub fn normalize_weak_head<'a>(
     normalization_context: &mut Vec<Option<Rc<Term<'a>>>>,
 ) -> Rc<Term<'a>> {
     match &term.variant {
-        Type => {
-            // The type of all types is already in beta normal form.
+        Type | Lambda(_, _, _) | Pi(_, _, _) => {
+            // These cases are already in beta normal form.
             term
         }
         Variable(_, index) => {
@@ -35,14 +35,6 @@ pub fn normalize_weak_head<'a>(
                     term
                 }
             }
-        }
-        Lambda(_, _, _) => {
-            // Lambdas are already in beta normal form.
-            term
-        }
-        Pi(_, _, _) => {
-            // Pi types are already in beta normal form.
-            term
         }
         Application(applicand, argument) => {
             // Reduce the applicand.
@@ -111,8 +103,7 @@ pub fn normalize_beta<'a>(
             // Reduce the domain.
             let normalized_domain = normalize_beta(domain.clone(), normalization_context);
 
-            // Temporarily add the variable's type to the context for the purpose of normalizing
-            // the body.
+            // Temporarily add the variable to the context for the purpose of normalizing the body.
             normalization_context.push(None);
 
             // Normalize the body.
@@ -132,8 +123,8 @@ pub fn normalize_beta<'a>(
             // Reduce the domain.
             let normalized_domain = normalize_beta(domain.clone(), normalization_context);
 
-            // Temporarily add the variable's type to the context for the purpose of normalizing
-            // the codomain.
+            // Temporarily add the variable the context for the purpose of normalizing the
+            // codomain.
             normalization_context.push(None);
 
             // Normalize the body.

--- a/src/normalizer.rs
+++ b/src/normalizer.rs
@@ -7,7 +7,79 @@ use crate::{
 };
 use std::rc::Rc;
 
-// This function reduces a term to beta normal form using applicative order reduction. Invariant:
+// This function reduces a term to weak head normal form using normal order reduction.
+// Invariant:
+// - When this function is finished, the context is left unmodified.
+pub fn normalize_weak_head<'a>(
+    term: Rc<Term<'a>>,
+    normalization_context: &mut Vec<Option<Rc<Term<'a>>>>,
+) -> Rc<Term<'a>> {
+    match &term.variant {
+        Type => {
+            // The type of all types is already in beta normal form.
+            term
+        }
+        Variable(_, index) => {
+            // Look up the definition in the context.
+            match &normalization_context[normalization_context.len() - 1 - *index] {
+                Some(definition) => {
+                    // Shift the definition so it's valid in the current context and then normalize
+                    // it.
+                    normalize_weak_head(
+                        shift(definition.clone(), 0, *index + 1),
+                        normalization_context,
+                    )
+                }
+                None => {
+                    // The variable doesn't have a definition. Just return it as a "neutral term".
+                    term
+                }
+            }
+        }
+        Lambda(_, _, _) => {
+            // Lambdas are already in beta normal form.
+            term
+        }
+        Pi(_, _, _) => {
+            // Pi types are already in beta normal form.
+            term
+        }
+        Application(applicand, argument) => {
+            // Reduce the applicand.
+            let normalized_applicand =
+                normalize_weak_head(applicand.clone(), normalization_context);
+
+            // Check if the applicand reduced to a lambda.
+            if let Lambda(_, _, body) = &normalized_applicand.variant {
+                // Perform beta reduction. Here we're doing normal order reduction.
+                normalize_weak_head(
+                    open(body.clone(), 0, argument.clone()),
+                    normalization_context,
+                )
+            } else {
+                // We didn't get a lambda. We're done here.
+                Rc::new(Term {
+                    source_range: term.source_range,
+                    group: true,
+                    variant: Application(normalized_applicand, argument.clone()),
+                })
+            }
+        }
+        Let(_, definition, body) => {
+            // Open the body, and normalize the result. Alternatively, we could have added the
+            // definition to the context and normalized the body, but then we still would have had
+            // to decrement the indices corresponding to free variables in the body (e.g., by
+            // opening).
+            normalize_weak_head(
+                open(body.clone(), 0, definition.clone()),
+                normalization_context,
+            )
+        }
+    }
+}
+
+// This function reduces a term to beta normal form using applicative order reduction.
+// Invariant:
 // - When this function is finished, the context is left unmodified.
 pub fn normalize_beta<'a>(
     term: Rc<Term<'a>>,
@@ -121,7 +193,7 @@ pub fn normalize_beta<'a>(
 #[cfg(test)]
 mod tests {
     use crate::{
-        normalizer::normalize_beta,
+        normalizer::{normalize_beta, normalize_weak_head},
         parser::parse,
         term::{
             Term,
@@ -133,7 +205,324 @@ mod tests {
     use std::rc::Rc;
 
     #[test]
-    fn normalize_type() {
+    fn normalize_weak_head_type() {
+        let parsing_context = [];
+        let mut normalization_context = vec![];
+        let source = TYPE_KEYWORD;
+
+        let tokens = tokenize(None, source).unwrap();
+        let term = parse(None, source, &tokens[..], &parsing_context[..]).unwrap();
+
+        assert_eq!(
+            *normalize_weak_head(Rc::new(term), &mut normalization_context),
+            Term {
+                source_range: Some((0, TYPE_KEYWORD.len())),
+                group: false,
+                variant: Type,
+            },
+        );
+    }
+
+    #[test]
+    fn normalize_weak_head_variable_no_definition() {
+        let parsing_context = ["x"];
+        let mut normalization_context = vec![None];
+        let source = "x";
+
+        let tokens = tokenize(None, source).unwrap();
+        let term = parse(None, source, &tokens[..], &parsing_context[..]).unwrap();
+
+        assert_eq!(
+            *normalize_weak_head(Rc::new(term), &mut normalization_context),
+            Term {
+                source_range: Some((0, 1)),
+                group: false,
+                variant: Variable("x", 0),
+            },
+        );
+    }
+
+    #[test]
+    fn normalize_weak_head_variable_definition() {
+        let parsing_context = ["x"];
+        let mut normalization_context = vec![Some(Rc::new(Term {
+            source_range: None,
+            group: false,
+            variant: Type,
+        }))];
+        let source = "x";
+
+        let tokens = tokenize(None, source).unwrap();
+        let term = parse(None, source, &tokens[..], &parsing_context[..]).unwrap();
+
+        assert_eq!(
+            *normalize_weak_head(Rc::new(term), &mut normalization_context),
+            Term {
+                source_range: None,
+                group: false,
+                variant: Type,
+            },
+        );
+    }
+
+    #[test]
+    fn normalize_weak_head_redex_under_lambda() {
+        let parsing_context = ["p", "q"];
+        let mut normalization_context = vec![None, None];
+        let source = "(x : ((y : type) => y) p) => ((z : type) => z) q";
+
+        let tokens = tokenize(None, source).unwrap();
+        let term = parse(None, source, &tokens[..], &parsing_context[..]).unwrap();
+
+        assert_eq!(
+            *normalize_weak_head(Rc::new(term), &mut normalization_context),
+            Term {
+                source_range: Some((0, 48)),
+                group: false,
+                variant: Lambda(
+                    "x",
+                    Rc::new(Term {
+                        source_range: Some((6, 24)),
+                        group: true,
+                        variant: Application(
+                            Rc::new(Term {
+                                source_range: Some((6, 21)),
+                                group: true,
+                                variant: Lambda(
+                                    "y",
+                                    Rc::new(Term {
+                                        source_range: Some((11, 15)),
+                                        group: false,
+                                        variant: Type,
+                                    }),
+                                    Rc::new(Term {
+                                        source_range: Some((20, 21)),
+                                        group: false,
+                                        variant: Variable("y", 0),
+                                    }),
+                                ),
+                            }),
+                            Rc::new(Term {
+                                source_range: Some((23, 24)),
+                                group: false,
+                                variant: Variable("p", 1),
+                            }),
+                        ),
+                    }),
+                    Rc::new(Term {
+                        source_range: Some((30, 48)),
+                        group: true,
+                        variant: Application(
+                            Rc::new(Term {
+                                source_range: Some((30, 45)),
+                                group: true,
+                                variant: Lambda(
+                                    "z",
+                                    Rc::new(Term {
+                                        source_range: Some((35, 39)),
+                                        group: false,
+                                        variant: Type,
+                                    }),
+                                    Rc::new(Term {
+                                        source_range: Some((44, 45)),
+                                        group: false,
+                                        variant: Variable("z", 0),
+                                    }),
+                                ),
+                            }),
+                            Rc::new(Term {
+                                source_range: Some((47, 48)),
+                                group: false,
+                                variant: Variable("q", 1),
+                            }),
+                        ),
+                    }),
+                ),
+            },
+        );
+    }
+
+    #[test]
+    fn normalize_weak_head_redex_under_pi() {
+        let parsing_context = ["p", "q"];
+        let mut normalization_context = vec![None, None];
+        let source = "(x : ((y : type) => y) p) -> ((z : type) => z) q";
+
+        let tokens = tokenize(None, source).unwrap();
+        let term = parse(None, source, &tokens[..], &parsing_context[..]).unwrap();
+
+        assert_eq!(
+            *normalize_weak_head(Rc::new(term), &mut normalization_context),
+            Term {
+                source_range: Some((0, 48)),
+                group: false,
+                variant: Pi(
+                    "x",
+                    Rc::new(Term {
+                        source_range: Some((6, 24)),
+                        group: true,
+                        variant: Application(
+                            Rc::new(Term {
+                                source_range: Some((6, 21)),
+                                group: true,
+                                variant: Lambda(
+                                    "y",
+                                    Rc::new(Term {
+                                        source_range: Some((11, 15)),
+                                        group: false,
+                                        variant: Type,
+                                    }),
+                                    Rc::new(Term {
+                                        source_range: Some((20, 21)),
+                                        group: false,
+                                        variant: Variable("y", 0),
+                                    }),
+                                ),
+                            }),
+                            Rc::new(Term {
+                                source_range: Some((23, 24)),
+                                group: false,
+                                variant: Variable("p", 1),
+                            }),
+                        ),
+                    }),
+                    Rc::new(Term {
+                        source_range: Some((30, 48)),
+                        group: true,
+                        variant: Application(
+                            Rc::new(Term {
+                                source_range: Some((30, 45)),
+                                group: true,
+                                variant: Lambda(
+                                    "z",
+                                    Rc::new(Term {
+                                        source_range: Some((35, 39)),
+                                        group: false,
+                                        variant: Type,
+                                    }),
+                                    Rc::new(Term {
+                                        source_range: Some((44, 45)),
+                                        group: false,
+                                        variant: Variable("z", 0),
+                                    }),
+                                ),
+                            }),
+                            Rc::new(Term {
+                                source_range: Some((47, 48)),
+                                group: false,
+                                variant: Variable("q", 1),
+                            }),
+                        ),
+                    }),
+                ),
+            },
+        );
+    }
+
+    #[test]
+    fn normalize_weak_head_non_redex() {
+        let parsing_context = ["y", "w"];
+        let mut normalization_context = vec![None, None];
+        let source = "(((x : type) => x) y) (((z : type) => z) w)";
+
+        let tokens = tokenize(None, source).unwrap();
+        let term = parse(None, source, &tokens[..], &parsing_context[..]).unwrap();
+
+        assert_eq!(
+            *normalize_weak_head(Rc::new(term), &mut normalization_context),
+            Term {
+                source_range: Some((2, 42)),
+                group: true,
+                variant: Application(
+                    Rc::new(Term {
+                        source_range: Some((19, 20)),
+                        group: true,
+                        variant: Variable("y", 1),
+                    }),
+                    Rc::new(Term {
+                        source_range: Some((24, 42)),
+                        group: true,
+                        variant: Application(
+                            Rc::new(Term {
+                                source_range: Some((24, 39)),
+                                group: true,
+                                variant: Lambda(
+                                    "z",
+                                    Rc::new(Term {
+                                        source_range: Some((29, 33)),
+                                        group: false,
+                                        variant: Type,
+                                    }),
+                                    Rc::new(Term {
+                                        source_range: Some((38, 39)),
+                                        group: false,
+                                        variant: Variable("z", 0),
+                                    }),
+                                ),
+                            }),
+                            Rc::new(Term {
+                                source_range: Some((41, 42)),
+                                group: false,
+                                variant: Variable("w", 0),
+                            }),
+                        ),
+                    }),
+                ),
+            },
+        );
+    }
+
+    #[test]
+    fn normalize_weak_head_redex() {
+        let parsing_context = ["y"];
+        let mut normalization_context = vec![None];
+        let source = "((x : type) => x) y";
+
+        let tokens = tokenize(None, source).unwrap();
+        let term = parse(None, source, &tokens[..], &parsing_context[..]).unwrap();
+
+        assert_eq!(
+            *normalize_weak_head(Rc::new(term), &mut normalization_context),
+            Term {
+                source_range: Some((18, 19)),
+                group: true,
+                variant: Variable("y", 0),
+            },
+        );
+    }
+
+    #[test]
+    fn normalize_weak_head_let() {
+        let parsing_context = ["y"];
+        let mut normalization_context = vec![None];
+        let source = "x = type; x y";
+
+        let tokens = tokenize(None, source).unwrap();
+        let term = parse(None, source, &tokens[..], &parsing_context[..]).unwrap();
+
+        assert_eq!(
+            *normalize_weak_head(Rc::new(term), &mut normalization_context),
+            Term {
+                source_range: Some((10, 13)),
+                group: true,
+                variant: Application(
+                    Rc::new(Term {
+                        source_range: Some((4, 8)),
+                        group: true,
+                        variant: Type,
+                    }),
+                    Rc::new(Term {
+                        source_range: Some((12, 13)),
+                        group: false,
+                        variant: Variable("y", 0),
+                    }),
+                ),
+            },
+        );
+    }
+
+    #[test]
+    fn normalize_beta_type() {
         let parsing_context = [];
         let mut normalization_context = vec![];
         let source = TYPE_KEYWORD;
@@ -152,7 +541,7 @@ mod tests {
     }
 
     #[test]
-    fn normalize_variable_no_definition() {
+    fn normalize_beta_variable_no_definition() {
         let parsing_context = ["x"];
         let mut normalization_context = vec![None];
         let source = "x";
@@ -171,7 +560,7 @@ mod tests {
     }
 
     #[test]
-    fn normalize_variable_definition() {
+    fn normalize_beta_variable_definition() {
         let parsing_context = ["x"];
         let mut normalization_context = vec![Some(Rc::new(Term {
             source_range: None,
@@ -194,7 +583,7 @@ mod tests {
     }
 
     #[test]
-    fn normalize_redex_under_lambda() {
+    fn normalize_beta_redex_under_lambda() {
         let parsing_context = ["p", "q"];
         let mut normalization_context = vec![None, None];
         let source = "(x : ((y : type) => y) p) => ((z : type) => z) q";
@@ -225,7 +614,7 @@ mod tests {
     }
 
     #[test]
-    fn normalize_redex_under_pi() {
+    fn normalize_beta_redex_under_pi() {
         let parsing_context = ["p", "q"];
         let mut normalization_context = vec![None, None];
         let source = "(x : ((y : type) => y) p) -> ((z : type) => z) q";
@@ -256,7 +645,7 @@ mod tests {
     }
 
     #[test]
-    fn normalize_non_redex() {
+    fn normalize_beta_non_redex() {
         let parsing_context = ["y", "w"];
         let mut normalization_context = vec![None, None];
         let source = "(((x : type) => x) y) (((z : type) => z) w)";
@@ -286,7 +675,7 @@ mod tests {
     }
 
     #[test]
-    fn normalize_redex() {
+    fn normalize_beta_redex() {
         let parsing_context = ["y"];
         let mut normalization_context = vec![None];
         let source = "((x : type) => x) y";
@@ -305,7 +694,7 @@ mod tests {
     }
 
     #[test]
-    fn normalize_let() {
+    fn normalize_beta_let() {
         let parsing_context = ["y"];
         let mut normalization_context = vec![None];
         let source = "x = type; x y";

--- a/src/type_checker.rs
+++ b/src/type_checker.rs
@@ -3,7 +3,6 @@ use crate::{
     equality::syntactically_equal,
     error::{throw, Error},
     format::CodeStr,
-    normalizer::normalize_beta,
     term::{
         Term,
         Variant::{Application, Lambda, Let, Pi, Type, Variable},
@@ -13,8 +12,6 @@ use crate::{
 use std::{path::Path, rc::Rc};
 
 // This is the top-level type checking function. Invariants:
-// - The types and definitions of the variables in the context are normalized.
-// - The type returned by this function is normalized.
 // - The two contexts have the same length.
 // - When this function is finished, the contexts are left unmodified.
 #[allow(clippy::too_many_lines)]
@@ -26,279 +23,270 @@ pub fn type_check<'a>(
     normalization_context: &mut Vec<Option<Rc<Term<'a>>>>,
 ) -> Result<Rc<Term<'a>>, Error> {
     // The type checking rules are syntax-directed, so here we pattern match on the syntax.
-    Ok(normalize_beta(
-        match &term.variant {
-            Type => Rc::new(TYPE_TERM),
-            Variable(_, index) => {
-                // Look up the type in the context, and shift it such that it's valid in the
-                // current context.
-                shift(
-                    typing_context[typing_context.len() - 1 - *index].clone(),
-                    0,
-                    *index + 1,
-                )
-            }
-            Lambda(variable, domain, body) => {
-                // Infer the type of the domain.
-                let domain_type = type_check(
-                    source_path,
-                    source_contents,
-                    &**domain,
-                    typing_context,
-                    normalization_context,
-                )?;
+    Ok(match &term.variant {
+        Type => Rc::new(TYPE_TERM),
+        Variable(_, index) => {
+            // Look up the type in the context, and shift it such that it's valid in the
+            // current context.
+            shift(
+                typing_context[typing_context.len() - 1 - *index].clone(),
+                0,
+                *index + 1,
+            )
+        }
+        Lambda(variable, domain, body) => {
+            // Infer the type of the domain.
+            let domain_type = type_check(
+                source_path,
+                source_contents,
+                &**domain,
+                typing_context,
+                normalization_context,
+            )?;
 
-                // Check that the type of the domain is the type of all types.
-                if !syntactically_equal(&*domain_type, &TYPE_TERM) {
-                    return Err(if let Some(source_range) = domain.source_range {
-                        throw(
-                            &format!(
-                                "This domain has type {} when {} was expected.",
-                                domain_type.to_string().code_str(),
-                                TYPE_TERM.to_string().code_str(),
-                            ),
-                            source_path,
-                            source_contents,
-                            source_range,
-                        )
-                    } else {
-                        Error {
-                            message: format!(
-                                "Found domain of type {} when {} was expected.",
-                                domain_type.to_string().code_str(),
-                                TYPE_TERM.to_string().code_str(),
-                            ),
-                            reason: None,
-                        }
-                    });
-                }
-
-                // Temporarily add the variable's type to the context for the purpose of inferring
-                // the codomain.
-                typing_context.push(domain.clone());
-                normalization_context.push(None);
-
-                // Infer the codomain.
-                let codomain_result = type_check(
-                    source_path,
-                    source_contents,
-                    &**body,
-                    typing_context,
-                    normalization_context,
-                );
-
-                // Restore the context.
-                normalization_context.pop();
-                typing_context.pop();
-
-                // Fail if the codomain is not well-typed.
-                let codomain = codomain_result?;
-
-                // Construct and return the pi type.
-                Rc::new(Term {
-                    source_range: term.source_range,
-                    group: false,
-                    variant: Pi(variable, domain.clone(), codomain),
-                })
-            }
-            Pi(_, domain, codomain) => {
-                // Infer the type of the domain.
-                let domain_type = type_check(
-                    source_path,
-                    source_contents,
-                    &**domain,
-                    typing_context,
-                    normalization_context,
-                )?;
-
-                // Check that the type of the domain is the type of all types.
-                if !syntactically_equal(&*domain_type, &TYPE_TERM) {
-                    return Err(if let Some(source_range) = domain.source_range {
-                        throw(
-                            &format!(
-                                "This domain has type {} when {} was expected.",
-                                domain_type.to_string().code_str(),
-                                TYPE_TERM.to_string().code_str(),
-                            ),
-                            source_path,
-                            source_contents,
-                            source_range,
-                        )
-                    } else {
-                        Error {
-                            message: format!(
-                                "Found domain of type {} when {} was expected.",
-                                domain_type.to_string().code_str(),
-                                TYPE_TERM.to_string().code_str(),
-                            ),
-                            reason: None,
-                        }
-                    });
-                }
-
-                // Temporarily add the variable's type to the context for the purpose of inferring
-                // the type of the codomain.
-                typing_context.push(domain.clone());
-                normalization_context.push(None);
-
-                // Infer the type of the codomain.
-                let codomain_type_result = type_check(
-                    source_path,
-                    source_contents,
-                    &**codomain,
-                    typing_context,
-                    normalization_context,
-                );
-
-                // Restore the context.
-                normalization_context.pop();
-                typing_context.pop();
-
-                // Fail if the type of the codomain is not well-typed.
-                let codomain_type = codomain_type_result?;
-
-                // Check that the type of the codomain is the type of all types.
-                if !syntactically_equal(&*codomain_type, &TYPE_TERM) {
-                    return Err(if let Some(source_range) = codomain.source_range {
-                        throw(
-                            &format!(
-                                "This codomain has type {} when {} was expected.",
-                                codomain_type.to_string().code_str(),
-                                TYPE_TERM.to_string().code_str(),
-                            ),
-                            source_path,
-                            source_contents,
-                            source_range,
-                        )
-                    } else {
-                        Error {
-                            message: format!(
-                                "Found codomain of type {} when {} was expected.",
-                                codomain_type.to_string().code_str(),
-                                TYPE_TERM.to_string().code_str(),
-                            ),
-                            reason: None,
-                        }
-                    });
-                }
-
-                // The type of a pi type is the type of all types.
-                Rc::new(TYPE_TERM)
-            }
-            Application(applicand, argument) => {
-                // Infer the type of the applicand.
-                let applicand_type = type_check(
-                    source_path,
-                    source_contents,
-                    &**applicand,
-                    typing_context,
-                    normalization_context,
-                )?;
-
-                // Make sure the type of the applicand is a pi type.
-                let (domain, codomain) = if let Pi(_, domain, codomain) = &applicand_type.variant {
-                    (domain, codomain)
+            // Check that the type of the domain is the type of all types.
+            if !syntactically_equal(&*domain_type, &TYPE_TERM) {
+                return Err(if let Some(source_range) = domain.source_range {
+                    throw(
+                        &format!(
+                            "This domain has type {} when {} was expected.",
+                            domain_type.to_string().code_str(),
+                            TYPE_TERM.to_string().code_str(),
+                        ),
+                        source_path,
+                        source_contents,
+                        source_range,
+                    )
                 } else {
-                    return Err(if let Some(source_range) = applicand.source_range {
-                        throw(
-                            &format!(
-                                "This has type {} when a pi type was expected.",
-                                applicand_type.to_string().code_str(),
-                            ),
-                            source_path,
-                            source_contents,
-                            source_range,
-                        )
-                    } else {
-                        Error {
-                            message: format!(
-                                "Applicand {} has type {} when a pi type was expected.",
-                                applicand.to_string().code_str(),
-                                applicand_type.to_string().code_str(),
-                            ),
-                            reason: None,
-                        }
-                    });
-                };
-
-                // Infer the type of the argument.
-                let argument_type = type_check(
-                    source_path,
-                    source_contents,
-                    &**argument,
-                    typing_context,
-                    normalization_context,
-                )?;
-
-                // Check that the argument type equals the domain.
-                if !syntactically_equal(&*argument_type, &**domain) {
-                    return Err(if let Some(source_range) = argument.source_range {
-                        throw(
-                            &format!(
-                                "This has type {} when {} was expected.",
-                                argument_type.to_string().code_str(),
-                                domain.to_string().code_str(),
-                            ),
-                            source_path,
-                            source_contents,
-                            source_range,
-                        )
-                    } else {
-                        Error {
-                            message: format!(
-                                "Argument {} has type {} when {} was expected.",
-                                argument.to_string().code_str(),
-                                argument_type.to_string().code_str(),
-                                domain.to_string().code_str(),
-                            ),
-                            reason: None,
-                        }
-                    });
-                }
-
-                // Construct and return the codomain specialized to the argument.
-                open(codomain.clone(), 0, argument.clone())
+                    Error {
+                        message: format!(
+                            "Found domain of type {} when {} was expected.",
+                            domain_type.to_string().code_str(),
+                            TYPE_TERM.to_string().code_str(),
+                        ),
+                        reason: None,
+                    }
+                });
             }
-            Let(_, definition, body) => {
-                // Infer the type of the definition.
-                let definition_type = type_check(
-                    source_path,
-                    source_contents,
-                    &**definition,
-                    typing_context,
-                    normalization_context,
-                )?;
 
-                // Normalize the definition.
-                let normalized_definition =
-                    normalize_beta(definition.clone(), normalization_context);
+            // Temporarily add the variable's type to the context for the purpose of inferring
+            // the codomain.
+            typing_context.push(domain.clone());
+            normalization_context.push(None);
 
-                // Temporarily add the definition and its type to the context for the purpose of
-                // inferring the codomain.
-                typing_context.push(definition_type.clone());
-                normalization_context.push(Some(normalized_definition.clone()));
+            // Infer the codomain.
+            let codomain_result = type_check(
+                source_path,
+                source_contents,
+                &**body,
+                typing_context,
+                normalization_context,
+            );
 
-                // Infer the type of the body.
-                let body_type_result = type_check(
-                    source_path,
-                    source_contents,
-                    &**body,
-                    typing_context,
-                    normalization_context,
-                );
+            // Restore the context.
+            normalization_context.pop();
+            typing_context.pop();
 
-                // Restore the context.
-                normalization_context.pop();
-                typing_context.pop();
+            // Fail if the codomain is not well-typed.
+            let codomain = codomain_result?;
 
-                // Return the opened type of the body. Since the type has already been normalized,
-                // any references to the definition should have already been unfolded. This,
-                // opening merely decrements the indices.
-                open(body_type_result?, 0, normalized_definition)
+            // Construct and return the pi type.
+            Rc::new(Term {
+                source_range: term.source_range,
+                group: false,
+                variant: Pi(variable, domain.clone(), codomain),
+            })
+        }
+        Pi(_, domain, codomain) => {
+            // Infer the type of the domain.
+            let domain_type = type_check(
+                source_path,
+                source_contents,
+                &**domain,
+                typing_context,
+                normalization_context,
+            )?;
+
+            // Check that the type of the domain is the type of all types.
+            if !syntactically_equal(&*domain_type, &TYPE_TERM) {
+                return Err(if let Some(source_range) = domain.source_range {
+                    throw(
+                        &format!(
+                            "This domain has type {} when {} was expected.",
+                            domain_type.to_string().code_str(),
+                            TYPE_TERM.to_string().code_str(),
+                        ),
+                        source_path,
+                        source_contents,
+                        source_range,
+                    )
+                } else {
+                    Error {
+                        message: format!(
+                            "Found domain of type {} when {} was expected.",
+                            domain_type.to_string().code_str(),
+                            TYPE_TERM.to_string().code_str(),
+                        ),
+                        reason: None,
+                    }
+                });
             }
-        },
-        normalization_context,
-    ))
+
+            // Temporarily add the variable's type to the context for the purpose of inferring
+            // the type of the codomain.
+            typing_context.push(domain.clone());
+            normalization_context.push(None);
+
+            // Infer the type of the codomain.
+            let codomain_type_result = type_check(
+                source_path,
+                source_contents,
+                &**codomain,
+                typing_context,
+                normalization_context,
+            );
+
+            // Restore the context.
+            normalization_context.pop();
+            typing_context.pop();
+
+            // Fail if the type of the codomain is not well-typed.
+            let codomain_type = codomain_type_result?;
+
+            // Check that the type of the codomain is the type of all types.
+            if !syntactically_equal(&*codomain_type, &TYPE_TERM) {
+                return Err(if let Some(source_range) = codomain.source_range {
+                    throw(
+                        &format!(
+                            "This codomain has type {} when {} was expected.",
+                            codomain_type.to_string().code_str(),
+                            TYPE_TERM.to_string().code_str(),
+                        ),
+                        source_path,
+                        source_contents,
+                        source_range,
+                    )
+                } else {
+                    Error {
+                        message: format!(
+                            "Found codomain of type {} when {} was expected.",
+                            codomain_type.to_string().code_str(),
+                            TYPE_TERM.to_string().code_str(),
+                        ),
+                        reason: None,
+                    }
+                });
+            }
+
+            // The type of a pi type is the type of all types.
+            Rc::new(TYPE_TERM)
+        }
+        Application(applicand, argument) => {
+            // Infer the type of the applicand.
+            let applicand_type = type_check(
+                source_path,
+                source_contents,
+                &**applicand,
+                typing_context,
+                normalization_context,
+            )?;
+
+            // Make sure the type of the applicand is a pi type.
+            let (domain, codomain) = if let Pi(_, domain, codomain) = &applicand_type.variant {
+                (domain, codomain)
+            } else {
+                return Err(if let Some(source_range) = applicand.source_range {
+                    throw(
+                        &format!(
+                            "This has type {} when a pi type was expected.",
+                            applicand_type.to_string().code_str(),
+                        ),
+                        source_path,
+                        source_contents,
+                        source_range,
+                    )
+                } else {
+                    Error {
+                        message: format!(
+                            "Applicand {} has type {} when a pi type was expected.",
+                            applicand.to_string().code_str(),
+                            applicand_type.to_string().code_str(),
+                        ),
+                        reason: None,
+                    }
+                });
+            };
+
+            // Infer the type of the argument.
+            let argument_type = type_check(
+                source_path,
+                source_contents,
+                &**argument,
+                typing_context,
+                normalization_context,
+            )?;
+
+            // Check that the argument type equals the domain.
+            if !syntactically_equal(&*argument_type, &**domain) {
+                return Err(if let Some(source_range) = argument.source_range {
+                    throw(
+                        &format!(
+                            "This has type {} when {} was expected.",
+                            argument_type.to_string().code_str(),
+                            domain.to_string().code_str(),
+                        ),
+                        source_path,
+                        source_contents,
+                        source_range,
+                    )
+                } else {
+                    Error {
+                        message: format!(
+                            "Argument {} has type {} when {} was expected.",
+                            argument.to_string().code_str(),
+                            argument_type.to_string().code_str(),
+                            domain.to_string().code_str(),
+                        ),
+                        reason: None,
+                    }
+                });
+            }
+
+            // Construct and return the codomain specialized to the argument.
+            open(codomain.clone(), 0, argument.clone())
+        }
+        Let(_, definition, body) => {
+            // Infer the type of the definition.
+            let definition_type = type_check(
+                source_path,
+                source_contents,
+                &**definition,
+                typing_context,
+                normalization_context,
+            )?;
+
+            // Temporarily add the definition and its type to the context for the purpose of
+            // inferring the codomain.
+            typing_context.push(definition_type.clone());
+            normalization_context.push(Some(definition.clone()));
+
+            // Infer the type of the body.
+            let body_type_result = type_check(
+                source_path,
+                source_contents,
+                &**body,
+                typing_context,
+                normalization_context,
+            );
+
+            // Restore the context.
+            normalization_context.pop();
+            typing_context.pop();
+
+            // Return the opened type of the body.
+            open(body_type_result?, 0, definition.clone())
+        }
+    })
 }
 
 #[cfg(test)]

--- a/src/type_checker.rs
+++ b/src/type_checker.rs
@@ -3,7 +3,7 @@ use crate::{
     equality::syntactically_equal,
     error::{throw, Error},
     format::CodeStr,
-    normalizer::normalize,
+    normalizer::normalize_beta,
     term::{
         Term,
         Variant::{Application, Lambda, Let, Pi, Type, Variable},
@@ -26,7 +26,7 @@ pub fn type_check<'a>(
     normalization_context: &mut Vec<Option<Rc<Term<'a>>>>,
 ) -> Result<Rc<Term<'a>>, Error> {
     // The type checking rules are syntax-directed, so here we pattern match on the syntax.
-    Ok(normalize(
+    Ok(normalize_beta(
         &*match &term.variant {
             Type => Rc::new(TYPE_TERM),
             Variable(_, index) => {
@@ -270,7 +270,7 @@ pub fn type_check<'a>(
                 )?;
 
                 // Normalize the definition.
-                let normalized_definition = normalize(definition, normalization_context);
+                let normalized_definition = normalize_beta(definition, normalization_context);
 
                 // Temporarily add the definition and its type to the context for the purpose of
                 // inferring the codomain.

--- a/src/type_checker.rs
+++ b/src/type_checker.rs
@@ -22,7 +22,6 @@ pub fn type_check<'a>(
     typing_context: &mut Vec<Rc<Term<'a>>>,
     normalization_context: &mut Vec<Option<Rc<Term<'a>>>>,
 ) -> Result<Rc<Term<'a>>, Error> {
-    // The type checking rules are syntax-directed, so here we pattern match on the syntax.
     Ok(match &term.variant {
         Type => Rc::new(TYPE_TERM),
         Variable(_, index) => {


### PR DESCRIPTION
Implement lazy convertibility as described [here](https://github.com/sweirich/pi-forall/blob/2014/notes3.md#implementing-definitional-equality-see-equalhs). This allows some terms with no normal form to be considered definitionally equal.