### PR TITLE
When in doubt, always set the `group` flag to `true`

### DIFF
--- a/src/de_bruijn.rs
+++ b/src/de_bruijn.rs
@@ -75,8 +75,11 @@ pub fn open<'a>(
             }),
             Ordering::Less => term_to_open,
             Ordering::Equal => {
+                // Shift the term such that it's valid in the current context.
                 let shifted_term = shift(term_to_insert, 0, index_to_replace);
 
+                // Turn on the `group` flag to ensure it parses correctly in whatever term
+                // surrounds it.
                 Rc::new(Term {
                     source_range: shifted_term.source_range,
                     group: true,

--- a/src/normalizer.rs
+++ b/src/normalizer.rs
@@ -25,10 +25,18 @@ pub fn normalize_weak_head<'a>(
                 Some(definition) => {
                     // Shift the definition so it's valid in the current context and then normalize
                     // it.
-                    normalize_weak_head(
+                    let normalized_shifted_definition = normalize_weak_head(
                         shift(definition.clone(), 0, *index + 1),
                         normalization_context,
-                    )
+                    );
+
+                    // Turn on the `group` flag to ensure it parses correctly in whatever term
+                    // surrounds it.
+                    Rc::new(Term {
+                        source_range: normalized_shifted_definition.source_range,
+                        group: true,
+                        variant: normalized_shifted_definition.variant.clone(),
+                    })
                 }
                 None => {
                     // The variable doesn't have a definition. Just return it as a "neutral term".
@@ -88,10 +96,18 @@ pub fn normalize_beta<'a>(
                 Some(definition) => {
                     // Shift the definition so it's valid in the current context and then normalize
                     // it.
-                    normalize_beta(
+                    let normalized_shifted_definition = normalize_beta(
                         shift(definition.clone(), 0, *index + 1),
                         normalization_context,
-                    )
+                    );
+
+                    // Turn on the `group` flag to ensure it parses correctly in whatever term
+                    // surrounds it.
+                    Rc::new(Term {
+                        source_range: normalized_shifted_definition.source_range,
+                        group: true,
+                        variant: normalized_shifted_definition.variant.clone(),
+                    })
                 }
                 None => {
                     // The variable doesn't have a definition. Just return it as a "neutral term".
@@ -250,7 +266,7 @@ mod tests {
             *normalize_weak_head(Rc::new(term), &mut normalization_context),
             Term {
                 source_range: None,
-                group: false,
+                group: true,
                 variant: Type,
             },
         );
@@ -567,7 +583,7 @@ mod tests {
             *normalize_beta(Rc::new(term), &mut normalization_context),
             Term {
                 source_range: None,
-                group: false,
+                group: true,
                 variant: Type
             },
         );

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -545,7 +545,7 @@ fn parse_term<'a, 'b>(
     cache_return!(cache, Term, start, None)
 }
 
-// Parse a variable.
+// Parse the type of all types.
 fn parse_type<'a, 'b>(
     cache: &mut Cache<'a, 'b>,
     tokens: &'b [Token<'a>],

--- a/src/type_checker.rs
+++ b/src/type_checker.rs
@@ -27,11 +27,19 @@ pub fn type_check<'a>(
         Variable(_, index) => {
             // Look up the type in the context, and shift it such that it's valid in the
             // current context.
-            shift(
+            let shifted_type = shift(
                 typing_context[typing_context.len() - 1 - *index].clone(),
                 0,
                 *index + 1,
-            )
+            );
+
+            // Turn on the `group` flag to ensure it parses correctly in whatever term surrounds
+            // it.
+            Rc::new(Term {
+                source_range: shifted_type.source_range,
+                group: true,
+                variant: shifted_type.variant.clone(),
+            })
         }
         Lambda(variable, domain, body) => {
             // Infer the type of the domain.
@@ -96,7 +104,7 @@ pub fn type_check<'a>(
             // Construct and return the pi type.
             Rc::new(Term {
                 source_range: term.source_range,
-                group: false,
+                group: true,
                 variant: Pi(variable, domain.clone(), codomain),
             })
         }
@@ -522,7 +530,7 @@ mod tests {
                 &mut typing_context,
                 &mut normalization_context
             ),
-            "has type `b` when `a` was expected",
+            "has type `(b)` when `a` was expected",
         );
     }
 


### PR DESCRIPTION
When in doubt, always set the `group` flag on terms to `true`. This ensures that the term remains parse-able when printed.