### PR TITLE
When type checking an application, reduce the applicand type to weak head normal form before destructuring it as a pi type

### DIFF
--- a/src/type_checker.rs
+++ b/src/type_checker.rs
@@ -3,6 +3,7 @@ use crate::{
     equality::definitionally_equal,
     error::{throw, Error},
     format::CodeStr,
+    normalizer::normalize_weak_head,
     term::{
         Term,
         Variant::{Application, Lambda, Let, Pi, Type, Variable},
@@ -228,8 +229,12 @@ pub fn type_check<'a>(
                 normalization_context,
             )?;
 
+            // Reduce the type of the applicand to weak head normal form.
+            let applicand_type_whnf =
+                normalize_weak_head(applicand_type.clone(), normalization_context);
+
             // Make sure the type of the applicand is a pi type.
-            let (domain, codomain) = if let Pi(_, domain, codomain) = &applicand_type.variant {
+            let (domain, codomain) = if let Pi(_, domain, codomain) = &applicand_type_whnf.variant {
                 (domain, codomain)
             } else {
                 return Err(if let Some(source_range) = applicand.source_range {


### PR DESCRIPTION
When type checking an application, reduce the applicand type to weak head normal form before destructuring it as a pi type. This did not used to be necessary back when the `type_check` function returned fully normalized types, but that behavior was changed in https://github.com/gramlang/gram/pull/172.

I encountered this bug when trying to type check the following term, which now works after this change:

```gram
power = (S : type) => S -> type;
U = (X : type) -> ((power (power X) -> X) -> power (power X));
tau = (t : power (power U)) => (X : type) => (f : power (power X) -> X) => (p : power X) => t ((x : U) => p (f (x X f)));
type
```

This term is a partial attempt at encoding Girard's paradox in Gram.