### PR TITLE
Fix the `source_range` calculation for groups in the parser

### DIFF
--- a/src/normalizer.rs
+++ b/src/normalizer.rs
@@ -282,11 +282,11 @@ mod tests {
                 variant: Lambda(
                     "x",
                     Rc::new(Term {
-                        source_range: Some((6, 24)),
+                        source_range: Some((5, 24)),
                         group: true,
                         variant: Application(
                             Rc::new(Term {
-                                source_range: Some((6, 21)),
+                                source_range: Some((5, 22)),
                                 group: true,
                                 variant: Lambda(
                                     "y",
@@ -310,11 +310,11 @@ mod tests {
                         ),
                     }),
                     Rc::new(Term {
-                        source_range: Some((30, 48)),
+                        source_range: Some((29, 48)),
                         group: true,
                         variant: Application(
                             Rc::new(Term {
-                                source_range: Some((30, 45)),
+                                source_range: Some((29, 46)),
                                 group: true,
                                 variant: Lambda(
                                     "z",
@@ -359,11 +359,11 @@ mod tests {
                 variant: Pi(
                     "x",
                     Rc::new(Term {
-                        source_range: Some((6, 24)),
+                        source_range: Some((5, 24)),
                         group: true,
                         variant: Application(
                             Rc::new(Term {
-                                source_range: Some((6, 21)),
+                                source_range: Some((5, 22)),
                                 group: true,
                                 variant: Lambda(
                                     "y",
@@ -387,11 +387,11 @@ mod tests {
                         ),
                     }),
                     Rc::new(Term {
-                        source_range: Some((30, 48)),
+                        source_range: Some((29, 48)),
                         group: true,
                         variant: Application(
                             Rc::new(Term {
-                                source_range: Some((30, 45)),
+                                source_range: Some((29, 46)),
                                 group: true,
                                 variant: Lambda(
                                     "z",
@@ -431,7 +431,7 @@ mod tests {
         assert_eq!(
             *normalize_weak_head(Rc::new(term), &mut normalization_context),
             Term {
-                source_range: Some((2, 42)),
+                source_range: Some((0, 43)),
                 group: true,
                 variant: Application(
                     Rc::new(Term {
@@ -440,11 +440,11 @@ mod tests {
                         variant: Variable("y", 1),
                     }),
                     Rc::new(Term {
-                        source_range: Some((24, 42)),
+                        source_range: Some((23, 42)),
                         group: true,
                         variant: Application(
                             Rc::new(Term {
-                                source_range: Some((24, 39)),
+                                source_range: Some((23, 40)),
                                 group: true,
                                 variant: Lambda(
                                     "z",
@@ -656,7 +656,7 @@ mod tests {
         assert_eq!(
             *normalize_beta(Rc::new(term), &mut normalization_context),
             Term {
-                source_range: Some((2, 42)),
+                source_range: Some((0, 43)),
                 group: true,
                 variant: Application(
                     Rc::new(Term {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1061,7 +1061,10 @@ fn parse_group<'a, 'b>(
         start,
         Some((
             Term {
-                source_range: term.source_range,
+                source_range: Some((
+                    tokens[start].source_range.0,
+                    tokens[next - 1].source_range.1
+                )),
                 group: true,
                 variant: term.variant,
             },
@@ -1513,7 +1516,7 @@ mod tests {
         assert_eq!(
             parse(None, source, &tokens[..], &context[..]).unwrap(),
             Term {
-                source_range: Some((0, 6)),
+                source_range: Some((0, 7)),
                 group: false,
                 variant: Application(
                     Rc::new(Term {
@@ -1579,7 +1582,7 @@ mod tests {
         assert_eq!(
             parse(None, source, &tokens[..], &context[..]).unwrap(),
             Term {
-                source_range: Some((1, 2)),
+                source_range: Some((0, 3)),
                 group: true,
                 variant: Variable("x", 0),
             },


### PR DESCRIPTION
Fix the `source_range` calculation for groups in the parser. Pictures speak a thousand words:

Before:

<img width="507" alt="Screenshot 2020-02-13 18 30 04" src="https://user-images.githubusercontent.com/796574/74496226-e6a33680-4e8e-11ea-88b8-5484035808ba.png">

After:

<img width="506" alt="Screenshot 2020-02-13 18 30 15" src="https://user-images.githubusercontent.com/796574/74496240-eefb7180-4e8e-11ea-8e75-47bcc75a113e.png">
