### PR TITLE
Introduce an intermediate AST in preparation for mutually recursive let bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pad 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -87,7 +87,7 @@ dependencies = [
 
 [[package]]
 name = "scopeguard"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -163,7 +163,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)" = "1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8"
 "checksum pad 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "d2ad9b889f1b12e0b9ee24db044b5129150d5eada288edc800f789928dc8c0e3"
-"checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
+"checksum scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum term_size 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9e5b9a66db815dcfd2da92db471106457082577c3c278d4138ab3e3b4e189327"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"

--- a/grammar.y
+++ b/grammar.y
@@ -2,6 +2,11 @@
   This Bison file exists only to ensure that the grammar is unambigous. The resulting Bison-
   generated parser isn't used. Instead, we use the hand-written packrat parser in `src/parser.rs`
   for better control over error messages.
+
+  Application is right-associative in this grammar to avoid left-recursion, since packrat parsers
+  can't handle left-recursion. Note however that non-grouped applications are re-associated to the
+  left in a post-processing step, because left-associative application gives better ergonomics for
+  currying. See [ref:reassociate-applications] for details.
 */
 
 /*

--- a/src/normalizer.rs
+++ b/src/normalizer.rs
@@ -25,18 +25,10 @@ pub fn normalize_weak_head<'a>(
                 Some(definition) => {
                     // Shift the definition so it's valid in the current context and then normalize
                     // it.
-                    let normalized_shifted_definition = normalize_weak_head(
+                    normalize_weak_head(
                         shift(definition.clone(), 0, *index + 1),
                         normalization_context,
-                    );
-
-                    // Turn on the `group` flag to ensure it parses correctly in whatever term
-                    // surrounds it.
-                    Rc::new(Term {
-                        source_range: normalized_shifted_definition.source_range,
-                        group: true,
-                        variant: normalized_shifted_definition.variant.clone(),
-                    })
+                    )
                 }
                 None => {
                     // The variable doesn't have a definition. Just return it as a "neutral term".
@@ -60,7 +52,6 @@ pub fn normalize_weak_head<'a>(
                 // We didn't get a lambda. We're done here.
                 Rc::new(Term {
                     source_range: term.source_range,
-                    group: true,
                     variant: Application(normalized_applicand, argument.clone()),
                 })
             }
@@ -93,18 +84,10 @@ pub fn normalize_beta<'a>(
                 Some(definition) => {
                     // Shift the definition so it's valid in the current context and then normalize
                     // it.
-                    let normalized_shifted_definition = normalize_beta(
+                    normalize_beta(
                         shift(definition.clone(), 0, *index + 1),
                         normalization_context,
-                    );
-
-                    // Turn on the `group` flag to ensure it parses correctly in whatever term
-                    // surrounds it.
-                    Rc::new(Term {
-                        source_range: normalized_shifted_definition.source_range,
-                        group: true,
-                        variant: normalized_shifted_definition.variant.clone(),
-                    })
+                    )
                 }
                 None => {
                     // The variable doesn't have a definition. Just return it as a "neutral term".
@@ -128,7 +111,6 @@ pub fn normalize_beta<'a>(
             // Construct and return the normalized lambda.
             Rc::new(Term {
                 source_range: term.source_range,
-                group: true,
                 variant: Lambda(variable, normalized_domain, normalized_body),
             })
         }
@@ -149,7 +131,6 @@ pub fn normalize_beta<'a>(
             // Construct and return the normalized pi type.
             Rc::new(Term {
                 source_range: term.source_range,
-                group: true,
                 variant: Pi(variable, normalized_domain, normalized_codomain),
             })
         }
@@ -171,7 +152,6 @@ pub fn normalize_beta<'a>(
                 // We didn't get a lambda. We're done here.
                 Rc::new(Term {
                     source_range: term.source_range,
-                    group: true,
                     variant: Application(normalized_applicand, normalized_argument),
                 })
             }
@@ -217,7 +197,6 @@ mod tests {
             *normalize_weak_head(Rc::new(term), &mut normalization_context),
             Term {
                 source_range: Some((0, TYPE_KEYWORD.len())),
-                group: false,
                 variant: Type,
             },
         );
@@ -236,7 +215,6 @@ mod tests {
             *normalize_weak_head(Rc::new(term), &mut normalization_context),
             Term {
                 source_range: Some((0, 1)),
-                group: false,
                 variant: Variable("x", 0),
             },
         );
@@ -247,7 +225,6 @@ mod tests {
         let parsing_context = ["x"];
         let mut normalization_context = vec![Some(Rc::new(Term {
             source_range: None,
-            group: false,
             variant: Type,
         }))];
         let source = "x";
@@ -259,7 +236,6 @@ mod tests {
             *normalize_weak_head(Rc::new(term), &mut normalization_context),
             Term {
                 source_range: None,
-                group: true,
                 variant: Type,
             },
         );
@@ -278,61 +254,50 @@ mod tests {
             *normalize_weak_head(Rc::new(term), &mut normalization_context),
             Term {
                 source_range: Some((0, 48)),
-                group: false,
                 variant: Lambda(
                     "x",
                     Rc::new(Term {
                         source_range: Some((5, 24)),
-                        group: true,
                         variant: Application(
                             Rc::new(Term {
                                 source_range: Some((5, 22)),
-                                group: true,
                                 variant: Lambda(
                                     "y",
                                     Rc::new(Term {
                                         source_range: Some((11, 15)),
-                                        group: false,
                                         variant: Type,
                                     }),
                                     Rc::new(Term {
                                         source_range: Some((20, 21)),
-                                        group: false,
                                         variant: Variable("y", 0),
                                     }),
                                 ),
                             }),
                             Rc::new(Term {
                                 source_range: Some((23, 24)),
-                                group: false,
                                 variant: Variable("p", 1),
                             }),
                         ),
                     }),
                     Rc::new(Term {
                         source_range: Some((29, 48)),
-                        group: true,
                         variant: Application(
                             Rc::new(Term {
                                 source_range: Some((29, 46)),
-                                group: true,
                                 variant: Lambda(
                                     "z",
                                     Rc::new(Term {
                                         source_range: Some((35, 39)),
-                                        group: false,
                                         variant: Type,
                                     }),
                                     Rc::new(Term {
                                         source_range: Some((44, 45)),
-                                        group: false,
                                         variant: Variable("z", 0),
                                     }),
                                 ),
                             }),
                             Rc::new(Term {
                                 source_range: Some((47, 48)),
-                                group: false,
                                 variant: Variable("q", 1),
                             }),
                         ),
@@ -355,61 +320,50 @@ mod tests {
             *normalize_weak_head(Rc::new(term), &mut normalization_context),
             Term {
                 source_range: Some((0, 48)),
-                group: false,
                 variant: Pi(
                     "x",
                     Rc::new(Term {
                         source_range: Some((5, 24)),
-                        group: true,
                         variant: Application(
                             Rc::new(Term {
                                 source_range: Some((5, 22)),
-                                group: true,
                                 variant: Lambda(
                                     "y",
                                     Rc::new(Term {
                                         source_range: Some((11, 15)),
-                                        group: false,
                                         variant: Type,
                                     }),
                                     Rc::new(Term {
                                         source_range: Some((20, 21)),
-                                        group: false,
                                         variant: Variable("y", 0),
                                     }),
                                 ),
                             }),
                             Rc::new(Term {
                                 source_range: Some((23, 24)),
-                                group: false,
                                 variant: Variable("p", 1),
                             }),
                         ),
                     }),
                     Rc::new(Term {
                         source_range: Some((29, 48)),
-                        group: true,
                         variant: Application(
                             Rc::new(Term {
                                 source_range: Some((29, 46)),
-                                group: true,
                                 variant: Lambda(
                                     "z",
                                     Rc::new(Term {
                                         source_range: Some((35, 39)),
-                                        group: false,
                                         variant: Type,
                                     }),
                                     Rc::new(Term {
                                         source_range: Some((44, 45)),
-                                        group: false,
                                         variant: Variable("z", 0),
                                     }),
                                 ),
                             }),
                             Rc::new(Term {
                                 source_range: Some((47, 48)),
-                                group: false,
                                 variant: Variable("q", 1),
                             }),
                         ),
@@ -432,37 +386,30 @@ mod tests {
             *normalize_weak_head(Rc::new(term), &mut normalization_context),
             Term {
                 source_range: Some((0, 43)),
-                group: true,
                 variant: Application(
                     Rc::new(Term {
                         source_range: Some((19, 20)),
-                        group: true,
                         variant: Variable("y", 1),
                     }),
                     Rc::new(Term {
                         source_range: Some((23, 42)),
-                        group: true,
                         variant: Application(
                             Rc::new(Term {
                                 source_range: Some((23, 40)),
-                                group: true,
                                 variant: Lambda(
                                     "z",
                                     Rc::new(Term {
                                         source_range: Some((29, 33)),
-                                        group: false,
                                         variant: Type,
                                     }),
                                     Rc::new(Term {
                                         source_range: Some((38, 39)),
-                                        group: false,
                                         variant: Variable("z", 0),
                                     }),
                                 ),
                             }),
                             Rc::new(Term {
                                 source_range: Some((41, 42)),
-                                group: false,
                                 variant: Variable("w", 0),
                             }),
                         ),
@@ -485,7 +432,6 @@ mod tests {
             *normalize_weak_head(Rc::new(term), &mut normalization_context),
             Term {
                 source_range: Some((18, 19)),
-                group: true,
                 variant: Variable("y", 0),
             },
         );
@@ -504,16 +450,13 @@ mod tests {
             *normalize_weak_head(Rc::new(term), &mut normalization_context),
             Term {
                 source_range: Some((10, 13)),
-                group: true,
                 variant: Application(
                     Rc::new(Term {
                         source_range: Some((4, 8)),
-                        group: true,
                         variant: Type,
                     }),
                     Rc::new(Term {
                         source_range: Some((12, 13)),
-                        group: false,
                         variant: Variable("y", 0),
                     }),
                 ),
@@ -534,7 +477,6 @@ mod tests {
             *normalize_beta(Rc::new(term), &mut normalization_context),
             Term {
                 source_range: Some((0, TYPE_KEYWORD.len())),
-                group: false,
                 variant: Type,
             },
         );
@@ -553,7 +495,6 @@ mod tests {
             *normalize_beta(Rc::new(term), &mut normalization_context),
             Term {
                 source_range: Some((0, 1)),
-                group: false,
                 variant: Variable("x", 0),
             },
         );
@@ -564,7 +505,6 @@ mod tests {
         let parsing_context = ["x"];
         let mut normalization_context = vec![Some(Rc::new(Term {
             source_range: None,
-            group: false,
             variant: Type,
         }))];
         let source = "x";
@@ -576,7 +516,6 @@ mod tests {
             *normalize_beta(Rc::new(term), &mut normalization_context),
             Term {
                 source_range: None,
-                group: true,
                 variant: Type
             },
         );
@@ -595,17 +534,14 @@ mod tests {
             *normalize_beta(Rc::new(term), &mut normalization_context),
             Term {
                 source_range: Some((0, 48)),
-                group: true,
                 variant: Lambda(
                     "x",
                     Rc::new(Term {
                         source_range: Some((23, 24)),
-                        group: true,
                         variant: Variable("p", 1),
                     }),
                     Rc::new(Term {
                         source_range: Some((47, 48)),
-                        group: true,
                         variant: Variable("q", 1),
                     }),
                 ),
@@ -626,17 +562,14 @@ mod tests {
             *normalize_beta(Rc::new(term), &mut normalization_context),
             Term {
                 source_range: Some((0, 48)),
-                group: true,
                 variant: Pi(
                     "x",
                     Rc::new(Term {
                         source_range: Some((23, 24)),
-                        group: true,
                         variant: Variable("p", 1),
                     }),
                     Rc::new(Term {
                         source_range: Some((47, 48)),
-                        group: true,
                         variant: Variable("q", 1),
                     }),
                 ),
@@ -657,16 +590,13 @@ mod tests {
             *normalize_beta(Rc::new(term), &mut normalization_context),
             Term {
                 source_range: Some((0, 43)),
-                group: true,
                 variant: Application(
                     Rc::new(Term {
                         source_range: Some((19, 20)),
-                        group: true,
                         variant: Variable("y", 1),
                     }),
                     Rc::new(Term {
                         source_range: Some((41, 42)),
-                        group: true,
                         variant: Variable("w", 0),
                     }),
                 ),
@@ -687,7 +617,6 @@ mod tests {
             *normalize_beta(Rc::new(term), &mut normalization_context),
             Term {
                 source_range: Some((18, 19)),
-                group: true,
                 variant: Variable("y", 0),
             },
         );
@@ -706,16 +635,13 @@ mod tests {
             *normalize_beta(Rc::new(term), &mut normalization_context),
             Term {
                 source_range: Some((10, 13)),
-                group: true,
                 variant: Application(
                     Rc::new(Term {
                         source_range: Some((4, 8)),
-                        group: true,
                         variant: Type,
                     }),
                     Rc::new(Term {
                         source_range: Some((12, 13)),
-                        group: false,
                         variant: Variable("y", 0),
                     }),
                 ),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::{throw, Error},
     format::CodeStr,
-    term::{self, Term},
+    term,
     token::{self, Token},
 };
 use scopeguard::defer;
@@ -39,6 +39,39 @@ use std::{cell::RefCell, collections::HashMap, path::Path, rc::Rc};
 
 // This represents a fresh variable name. It's never added to the context.
 pub const PLACEHOLDER_VARIABLE: &str = "_";
+
+// The token stream is parsed into an abstract syntax tree (AST). This struct represents a node in
+// an AST. This is similar to `term::Term`, except:
+// - It doesn't contain De Bruijn indices.
+// - It has a `group` field (see see [ref:group-flag]).
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Term<'a> {
+    pub source_range: (usize, usize), // [start, end)
+    pub group: bool,                  // For an explanation of this field, see [ref:group-flag].
+    pub variant: Variant<'a>,
+}
+
+// Each term has a "variant" describing what kind of term it is.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Variant<'a> {
+    // This is the type of all types, including itself.
+    Type,
+
+    // A variable is a placeholder bound by a lambda, pi type, or let.
+    Variable(&'a str),
+
+    // A lambda, or dependent function, is a computable function.
+    Lambda(&'a str, Rc<Term<'a>>, Rc<Term<'a>>),
+
+    // Pi types, or dependent function types, are the types ascribed to lambdas.
+    Pi(&'a str, Rc<Term<'a>>, Rc<Term<'a>>),
+
+    // An application is the act of applying a lambda to an argument.
+    Application(Rc<Term<'a>>, Rc<Term<'a>>),
+
+    // A let is a local variable definition.
+    Let(&'a str, Rc<Term<'a>>, Rc<Term<'a>>),
+}
 
 // When memoizing a function, we'll use this enum to identify which function is being memoized.
 #[derive(Debug, Eq, Hash, PartialEq)]
@@ -288,37 +321,39 @@ pub fn parse<'a>(
     source_contents: &'a str,
     tokens: &[Token<'a>],
     context: &[&'a str],
-) -> Result<Term<'a>, Error> {
+) -> Result<term::Term<'a>, Error> {
     // Construct a hash table to memoize parsing results.
     let mut cache = Cache::new();
-
-    // Construct a mutable context.
-    let mut context: HashMap<&'a str, usize> = context
-        .iter()
-        .enumerate()
-        .map(|(i, variable)| (*variable, i))
-        .collect();
 
     // Construct a default error in case none of the tokens can be parsed.
     let mut error: ParseError = (None, 0);
 
     // Parse the term.
-    let result = parse_term(
-        &mut cache,
-        tokens,
-        0,
-        context.len(),
-        &mut context,
-        &mut error,
-    );
+    let result = parse_term(&mut cache, tokens, 0, &mut error);
 
     // Check if we managed to parse something.
     let first_unparsed_token = if let Some((term, next)) = result {
         // We parsed something, but did we parse everything?
         if next == tokens.len() {
             // We parsed everything. Flip the associativity of applications with non-grouped
-            // arguments from right to left and return the result [ref:reassociate-applications].
-            return Ok((*reassociate_applications(None, Rc::new(term))).clone());
+            // arguments from right to left.
+            let reassociated_term = reassociate_applications(None, Rc::new(term));
+
+            // Construct a mutable context.
+            let mut context: HashMap<&'a str, usize> = context
+                .iter()
+                .enumerate()
+                .map(|(i, variable)| (*variable, i))
+                .collect();
+
+            // Resolve variables and return the term.
+            return Ok(resolve_variables(
+                source_path,
+                source_contents,
+                &*reassociated_term,
+                context.len(),
+                &mut context,
+            )?);
         } else {
             // We didn't parse all the tokens. Remember which one we stopped at.
             next
@@ -365,38 +400,32 @@ fn reassociate_applications<'a>(acc: Option<Rc<Term<'a>>>, term: Rc<Term<'a>>) -
     // to construct an application with the accumulator as the applicand and the reduced term as
     // the argument. In the application case, we build up the accumulator.
     let reduced = match &term.variant {
-        term::Variant::Type | term::Variant::Variable(_, _) => term,
-        term::Variant::Lambda(variable, domain, body) => Rc::new(Term {
+        Variant::Type | Variant::Variable(_) => term,
+        Variant::Lambda(variable, domain, body) => Rc::new(Term {
             source_range: term.source_range,
             group: term.group,
-            variant: term::Variant::Lambda(
+            variant: Variant::Lambda(
                 variable,
                 reassociate_applications(None, domain.clone()),
                 reassociate_applications(None, body.clone()),
             ),
         }),
-        term::Variant::Pi(variable, domain, codomain) => Rc::new(Term {
+        Variant::Pi(variable, domain, codomain) => Rc::new(Term {
             source_range: term.source_range,
             group: term.group,
-            variant: term::Variant::Pi(
+            variant: Variant::Pi(
                 variable,
                 reassociate_applications(None, domain.clone()),
                 reassociate_applications(None, codomain.clone()),
             ),
         }),
-        term::Variant::Application(applicand, argument) => {
+        Variant::Application(applicand, argument) => {
             return if argument.group {
                 if let Some(acc) = acc {
                     Rc::new(Term {
-                        source_range: if let (Some((start, _)), Some((_, end))) =
-                            (acc.source_range, argument.source_range)
-                        {
-                            Some((start, end))
-                        } else {
-                            None
-                        },
-                        group: true, // To ensure the resulting term is still parse-able when printed
-                        variant: term::Variant::Application(
+                        source_range: (acc.source_range.0, argument.source_range.1),
+                        group: true,
+                        variant: Variant::Application(
                             reassociate_applications(Some(acc), applicand.clone()),
                             reassociate_applications(None, argument.clone()),
                         ),
@@ -405,7 +434,7 @@ fn reassociate_applications<'a>(acc: Option<Rc<Term<'a>>>, term: Rc<Term<'a>>) -
                     Rc::new(Term {
                         source_range: term.source_range,
                         group: term.group,
-                        variant: term::Variant::Application(
+                        variant: Variant::Application(
                             reassociate_applications(None, applicand.clone()),
                             reassociate_applications(None, argument.clone()),
                         ),
@@ -415,15 +444,9 @@ fn reassociate_applications<'a>(acc: Option<Rc<Term<'a>>>, term: Rc<Term<'a>>) -
                 reassociate_applications(
                     Some(if let Some(acc) = acc {
                         Rc::new(Term {
-                            source_range: if let (Some((start, _)), Some((_, end))) =
-                                (acc.source_range, applicand.source_range)
-                            {
-                                Some((start, end))
-                            } else {
-                                None
-                            },
-                            group: true, // To ensure the resulting term is still parse-able when printed
-                            variant: term::Variant::Application(
+                            source_range: (acc.source_range.0, applicand.source_range.1),
+                            group: true,
+                            variant: Variant::Application(
                                 acc,
                                 reassociate_applications(None, applicand.clone()),
                             ),
@@ -435,10 +458,10 @@ fn reassociate_applications<'a>(acc: Option<Rc<Term<'a>>>, term: Rc<Term<'a>>) -
                 )
             };
         }
-        term::Variant::Let(variable, definition, body) => Rc::new(Term {
+        Variant::Let(variable, definition, body) => Rc::new(Term {
             source_range: term.source_range,
             group: term.group,
-            variant: term::Variant::Let(
+            variant: Variant::Let(
                 variable,
                 reassociate_applications(None, definition.clone()),
                 reassociate_applications(None, body.clone()),
@@ -450,19 +473,206 @@ fn reassociate_applications<'a>(acc: Option<Rc<Term<'a>>>, term: Rc<Term<'a>>) -
     // an application as described above. Otherwise, just return the reduced term.
     if let Some(acc) = acc {
         Rc::new(Term {
-            source_range: if let (Some((start, _)), Some((_, end))) =
-                (acc.source_range, reduced.source_range)
-            {
-                Some((start, end))
-            } else {
-                None
-            },
-            group: true, // To ensure the resulting term is still parse-able when printed
-            variant: term::Variant::Application(acc, reduced),
+            source_range: (acc.source_range.0, reduced.source_range.1),
+            group: true,
+            variant: Variant::Application(acc, reduced),
         })
     } else {
         reduced
     }
+}
+
+// Resolve variables into De Bruijn indices.
+#[allow(clippy::too_many_lines)]
+fn resolve_variables<'a>(
+    source_path: Option<&'a Path>,
+    source_contents: &'a str,
+    term: &Term<'a>,
+    depth: usize,
+    context: &mut HashMap<&'a str, usize>,
+) -> Result<term::Term<'a>, Error> {
+    Ok(match &term.variant {
+        Variant::Type => {
+            // There are no variables to resolve here.
+            term::Term {
+                source_range: Some(term.source_range),
+                variant: term::Variant::Type,
+            }
+        }
+        Variant::Variable(variable) => {
+            // Calculate the De Bruijn index of the variable.
+            let index = if let Some(variable_depth) = context.get(variable) {
+                depth - variable_depth - 1
+            } else {
+                return Err(throw(
+                    &format!("Undefined variable {}.", variable.code_str()),
+                    source_path,
+                    source_contents,
+                    term.source_range,
+                ));
+            };
+
+            // Construct the variable.
+            term::Term {
+                source_range: Some(term.source_range),
+                variant: term::Variant::Variable(variable, index),
+            }
+        }
+        Variant::Lambda(variable, domain, body) => {
+            // Resolve variables in the domain.
+            let resolved_domain =
+                resolve_variables(source_path, source_contents, &*domain, depth, context)?;
+
+            // If the variable is `PLACEHOLDER_VARIABLE`, don't check for naming conflicts, and
+            // don't add it to the context.
+            if *variable != PLACEHOLDER_VARIABLE {
+                // Fail if the variable is already in the context.
+                if context.contains_key(variable) {
+                    return Err(throw(
+                        &format!("Variable {} already exists.", variable.code_str()),
+                        source_path,
+                        source_contents,
+                        term.source_range,
+                    ));
+                }
+
+                // Add the variable to the context.
+                context.insert(variable, depth);
+            }
+
+            // Remove the variable from the context (if it was added) when the function
+            // returns.
+            let context_cell = RefCell::new(context);
+            defer! {{ context_cell.borrow_mut().remove(variable); }};
+
+            // Construct the lambda.
+            let mut guard = context_cell.borrow_mut();
+            term::Term {
+                source_range: Some(term.source_range),
+                variant: term::Variant::Lambda(
+                    variable,
+                    Rc::new(resolved_domain),
+                    Rc::new(resolve_variables(
+                        source_path,
+                        source_contents,
+                        &*body,
+                        depth + 1,
+                        &mut *guard,
+                    )?),
+                ),
+            }
+        }
+        Variant::Pi(variable, domain, codomain) => {
+            // Resolve variables in the domain.
+            let resolved_domain =
+                resolve_variables(source_path, source_contents, &*domain, depth, context)?;
+
+            // If the variable is `PLACEHOLDER_VARIABLE`, don't check for naming conflicts, and
+            // don't add it to the context.
+            if *variable != PLACEHOLDER_VARIABLE {
+                // Fail if the variable is already in the context.
+                if context.contains_key(variable) {
+                    return Err(throw(
+                        &format!("Variable {} already exists.", variable.code_str()),
+                        source_path,
+                        source_contents,
+                        term.source_range,
+                    ));
+                }
+
+                // Add the variable to the context.
+                context.insert(variable, depth);
+            }
+
+            // Remove the variable from the context (if it was added) when the function
+            // returns.
+            let context_cell = RefCell::new(context);
+            defer! {{ context_cell.borrow_mut().remove(variable); }};
+
+            // Construct the pi type.
+            let mut guard = context_cell.borrow_mut();
+            term::Term {
+                source_range: Some(term.source_range),
+                variant: term::Variant::Pi(
+                    variable,
+                    Rc::new(resolved_domain),
+                    Rc::new(resolve_variables(
+                        source_path,
+                        source_contents,
+                        &*codomain,
+                        depth + 1,
+                        &mut *guard,
+                    )?),
+                ),
+            }
+        }
+        Variant::Application(applicand, argument) => {
+            // Just resolve variables in the applicand and the argument.
+            term::Term {
+                source_range: Some(term.source_range),
+                variant: term::Variant::Application(
+                    Rc::new(resolve_variables(
+                        source_path,
+                        source_contents,
+                        &*applicand,
+                        depth,
+                        context,
+                    )?),
+                    Rc::new(resolve_variables(
+                        source_path,
+                        source_contents,
+                        &*argument,
+                        depth,
+                        context,
+                    )?),
+                ),
+            }
+        }
+        Variant::Let(variable, definition, body) => {
+            // Resolve variables in the definition.
+            let resolved_definition =
+                resolve_variables(source_path, source_contents, &*definition, depth, context)?;
+
+            // If the variable is `PLACEHOLDER_VARIABLE`, don't check for naming conflicts, and
+            // don't add it to the context.
+            if *variable != PLACEHOLDER_VARIABLE {
+                // Fail if the variable is already in the context.
+                if context.contains_key(variable) {
+                    return Err(throw(
+                        &format!("Variable {} already exists.", variable.code_str()),
+                        source_path,
+                        source_contents,
+                        term.source_range,
+                    ));
+                }
+
+                // Add the variable to the context.
+                context.insert(variable, depth);
+            }
+
+            // Remove the variable from the context (if it was added) when the function
+            // returns.
+            let context_cell = RefCell::new(context);
+            defer! {{ context_cell.borrow_mut().remove(variable); }};
+
+            // Construct the pi type.
+            let mut guard = context_cell.borrow_mut();
+            term::Term {
+                source_range: Some(term.source_range),
+                variant: term::Variant::Let(
+                    variable,
+                    Rc::new(resolved_definition),
+                    Rc::new(resolve_variables(
+                        source_path,
+                        source_contents,
+                        &*body,
+                        depth + 1,
+                        &mut *guard,
+                    )?),
+                ),
+            }
+        }
+    })
 }
 
 // Parse a term.
@@ -470,8 +680,6 @@ fn parse_term<'a, 'b>(
     cache: &mut Cache<'a, 'b>,
     tokens: &'b [Token<'a>],
     start: usize,
-    depth: usize,
-    context: &mut HashMap<&'a str, usize>,
     error: &mut ParseError<'a, 'b>,
 ) -> CacheResult<'a, 'b> {
     // Check the cache and make sure we have some tokens to parse.
@@ -482,7 +690,7 @@ fn parse_term<'a, 'b>(
         cache,
         NonDependentPi,
         start,
-        parse_non_dependent_pi(cache, tokens, start, depth, context, error),
+        parse_non_dependent_pi(cache, tokens, start, error),
     );
 
     // Try to parse an application.
@@ -490,7 +698,7 @@ fn parse_term<'a, 'b>(
         cache,
         Application,
         start,
-        parse_application(cache, tokens, start, depth, context, error),
+        parse_application(cache, tokens, start, error),
     );
 
     // Try to parse a let.
@@ -498,23 +706,18 @@ fn parse_term<'a, 'b>(
         cache,
         Application,
         start,
-        parse_let(cache, tokens, start, depth, context, error),
+        parse_let(cache, tokens, start, error),
     );
 
     // Try to parse the type of all types.
-    try_return!(
-        cache,
-        Type,
-        start,
-        parse_type(cache, tokens, start, depth, context, error),
-    );
+    try_return!(cache, Type, start, parse_type(cache, tokens, start, error),);
 
     // Try to parse a variable.
     try_return!(
         cache,
         Application,
         start,
-        parse_variable(cache, tokens, start, depth, context, error),
+        parse_variable(cache, tokens, start, error),
     );
 
     // Try to parse a pi type.
@@ -522,7 +725,7 @@ fn parse_term<'a, 'b>(
         cache,
         Application,
         start,
-        parse_pi(cache, tokens, start, depth, context, error),
+        parse_pi(cache, tokens, start, error),
     );
 
     // Try to parse a lambda.
@@ -530,7 +733,7 @@ fn parse_term<'a, 'b>(
         cache,
         Application,
         start,
-        parse_lambda(cache, tokens, start, depth, context, error),
+        parse_lambda(cache, tokens, start, error),
     );
 
     // Try to parse a group.
@@ -538,7 +741,7 @@ fn parse_term<'a, 'b>(
         cache,
         Application,
         start,
-        parse_group(cache, tokens, start, depth, context, error),
+        parse_group(cache, tokens, start, error),
     );
 
     // If we made it this far, the parse failed.
@@ -550,8 +753,6 @@ fn parse_type<'a, 'b>(
     cache: &mut Cache<'a, 'b>,
     tokens: &'b [Token<'a>],
     start: usize,
-    _depth: usize,
-    _context: &mut HashMap<&'a str, usize>,
     error: &mut ParseError<'a, 'b>,
 ) -> CacheResult<'a, 'b> {
     // Check the cache and make sure we have some tokens to parse.
@@ -567,9 +768,9 @@ fn parse_type<'a, 'b>(
         start,
         Some((
             Term {
-                source_range: Some(tokens[start].source_range),
+                source_range: tokens[start].source_range,
                 group: false,
-                variant: term::Variant::Type,
+                variant: Variant::Type,
             },
             next,
         )),
@@ -581,8 +782,6 @@ fn parse_variable<'a, 'b>(
     cache: &mut Cache<'a, 'b>,
     tokens: &'b [Token<'a>],
     start: usize,
-    depth: usize,
-    context: &mut HashMap<&'a str, usize>,
     error: &mut ParseError<'a, 'b>,
 ) -> CacheResult<'a, 'b> {
     // Check the cache and make sure we have some tokens to parse.
@@ -591,27 +790,6 @@ fn parse_variable<'a, 'b>(
     // Consume the variable.
     let (variable, next) = consume_identifier!(cache, Variable, start, tokens, start, error);
 
-    // Look up the variable in the context and compute its De Bruijn index.
-    let index = if let Some(variable_depth) = context.get(variable) {
-        depth - variable_depth - 1
-    } else {
-        if next > error.1 {
-            *error = (
-                Some(Rc::new(move |source_path, source_contents| {
-                    throw(
-                        &format!("Undefined variable {}.", variable.code_str()),
-                        source_path,
-                        source_contents,
-                        tokens[next - 1].source_range,
-                    )
-                }) as ErrorFactory),
-                next,
-            );
-        }
-
-        cache_return!(cache, Variable, start, None);
-    };
-
     // Construct and return the variable.
     cache_return!(
         cache,
@@ -619,9 +797,9 @@ fn parse_variable<'a, 'b>(
         start,
         Some((
             Term {
-                source_range: Some(tokens[start].source_range),
+                source_range: tokens[start].source_range,
                 group: false,
-                variant: term::Variant::Variable(variable, index),
+                variant: Variant::Variable(variable),
             },
             next,
         )),
@@ -633,8 +811,6 @@ fn parse_non_dependent_pi<'a, 'b>(
     cache: &mut Cache<'a, 'b>,
     tokens: &'b [Token<'a>],
     start: usize,
-    depth: usize,
-    context: &mut HashMap<&'a str, usize>,
     error: &mut ParseError<'a, 'b>,
 ) -> CacheResult<'a, 'b> {
     // Check the cache and make sure we have some tokens to parse.
@@ -645,7 +821,7 @@ fn parse_non_dependent_pi<'a, 'b>(
         cache,
         NonDependentPi,
         start,
-        parse_non_arrow_term(cache, tokens, start, depth, context, error),
+        parse_non_arrow_term(cache, tokens, start, error),
     );
 
     // Consume the arrow.
@@ -657,7 +833,7 @@ fn parse_non_dependent_pi<'a, 'b>(
             cache,
             NonDependentPi,
             start,
-            parse_term(cache, tokens, next, depth + 1, context, error),
+            parse_term(cache, tokens, next, error),
         )
     };
 
@@ -668,19 +844,9 @@ fn parse_non_dependent_pi<'a, 'b>(
         start,
         Some((
             Term {
-                source_range: if let ((start, _), Some((_, end))) =
-                    (tokens[start].source_range, codomain.source_range)
-                {
-                    Some((start, end))
-                } else {
-                    None
-                },
+                source_range: (tokens[start].source_range.0, codomain.source_range.1),
                 group: false,
-                variant: term::Variant::Pi(
-                    PLACEHOLDER_VARIABLE,
-                    Rc::new(domain),
-                    Rc::new(codomain)
-                ),
+                variant: Variant::Pi(PLACEHOLDER_VARIABLE, Rc::new(domain), Rc::new(codomain)),
             },
             next
         )),
@@ -692,8 +858,6 @@ fn parse_pi<'a, 'b>(
     cache: &mut Cache<'a, 'b>,
     tokens: &'b [Token<'a>],
     start: usize,
-    depth: usize,
-    context: &mut HashMap<&'a str, usize>,
     error: &mut ParseError<'a, 'b>,
 ) -> CacheResult<'a, 'b> {
     // Check the cache and make sure we have some tokens to parse.
@@ -709,12 +873,7 @@ fn parse_pi<'a, 'b>(
     let next = consume_token!(cache, Pi, start, tokens, Colon, next, error);
 
     // Parse the domain.
-    let (domain, next) = try_eval!(
-        cache,
-        Pi,
-        start,
-        parse_term(cache, tokens, next, depth, context, error),
-    );
+    let (domain, next) = try_eval!(cache, Pi, start, parse_term(cache, tokens, next, error),);
 
     // Consume the right parenthesis.
     let next = consume_token!(cache, Pi, start, tokens, RightParen, next, error);
@@ -722,47 +881,8 @@ fn parse_pi<'a, 'b>(
     // Consume the arrow.
     let next = consume_token!(cache, Pi, start, tokens, ThinArrow, next, error);
 
-    // If the variable is `PLACEHOLDER_VARIABLE`, don't check for naming conflicts, and don't add
-    // it to the context.
-    if variable != PLACEHOLDER_VARIABLE {
-        // Fail if the variable is already in the context.
-        if context.contains_key(variable) {
-            if next > error.1 {
-                *error = (
-                    Some(Rc::new(move |source_path, source_contents| {
-                        throw(
-                            &format!("Variable {} already exists.", variable.code_str()),
-                            source_path,
-                            source_contents,
-                            tokens[variable_pos].source_range,
-                        )
-                    }) as ErrorFactory),
-                    next,
-                );
-            }
-
-            cache_return!(cache, Pi, start, None);
-        }
-
-        // Add the variable to the context.
-        context.insert(variable, depth);
-    }
-
-    // Remove the variable from the context (if it was added) when the function returns.
-    let context_cell = RefCell::new(context);
-    defer! {{ context_cell.borrow_mut().remove(variable); }};
-
     // Parse the codomain.
-    let (codomain, next) = {
-        let mut guard = context_cell.borrow_mut();
-
-        try_eval!(
-            cache,
-            Pi,
-            start,
-            parse_term(cache, tokens, next, depth + 1, &mut *guard, error),
-        )
-    };
+    let (codomain, next) = try_eval!(cache, Pi, start, parse_term(cache, tokens, next, error));
 
     // Construct and return the pi type.
     cache_return!(
@@ -771,15 +891,9 @@ fn parse_pi<'a, 'b>(
         start,
         Some((
             Term {
-                source_range: if let ((start, _), Some((_, end))) =
-                    (tokens[start].source_range, codomain.source_range)
-                {
-                    Some((start, end))
-                } else {
-                    None
-                },
+                source_range: (tokens[start].source_range.0, codomain.source_range.1),
                 group: false,
-                variant: term::Variant::Pi(variable, Rc::new(domain), Rc::new(codomain)),
+                variant: Variant::Pi(variable, Rc::new(domain), Rc::new(codomain)),
             },
             next
         )),
@@ -791,8 +905,6 @@ fn parse_lambda<'a, 'b>(
     cache: &mut Cache<'a, 'b>,
     tokens: &'b [Token<'a>],
     start: usize,
-    depth: usize,
-    context: &mut HashMap<&'a str, usize>,
     error: &mut ParseError<'a, 'b>,
 ) -> CacheResult<'a, 'b> {
     // Check the cache and make sure we have some tokens to parse.
@@ -808,12 +920,7 @@ fn parse_lambda<'a, 'b>(
     let next = consume_token!(cache, Lambda, start, tokens, Colon, next, error);
 
     // Parse the domain.
-    let (domain, next) = try_eval!(
-        cache,
-        Lambda,
-        start,
-        parse_term(cache, tokens, next, depth, context, error),
-    );
+    let (domain, next) = try_eval!(cache, Lambda, start, parse_term(cache, tokens, next, error),);
 
     // Consume the right parenthesis.
     let next = consume_token!(cache, Lambda, start, tokens, RightParen, next, error);
@@ -821,47 +928,8 @@ fn parse_lambda<'a, 'b>(
     // Consume the arrow.
     let next = consume_token!(cache, Lambda, start, tokens, ThickArrow, next, error);
 
-    // If the variable is `PLACEHOLDER_VARIABLE`, don't check for naming conflicts, and don't add
-    // it to the context.
-    if variable != PLACEHOLDER_VARIABLE {
-        // Fail if the variable is already in the context.
-        if context.contains_key(variable) {
-            if next > error.1 {
-                *error = (
-                    Some(Rc::new(move |source_path, source_contents| {
-                        throw(
-                            &format!("Variable {} already exists.", variable.code_str()),
-                            source_path,
-                            source_contents,
-                            tokens[variable_pos].source_range,
-                        )
-                    }) as ErrorFactory),
-                    next,
-                );
-            }
-
-            cache_return!(cache, Lambda, start, None);
-        }
-
-        // Add the variable to the context.
-        context.insert(variable, depth);
-    }
-
-    // Remove the variable from the context (if it was added) when the function returns.
-    let context_cell = RefCell::new(context);
-    defer! {{ context_cell.borrow_mut().remove(variable); }};
-
     // Parse the body.
-    let (body, next) = {
-        let mut guard = context_cell.borrow_mut();
-
-        try_eval!(
-            cache,
-            Lambda,
-            start,
-            parse_term(cache, tokens, next, depth + 1, &mut *guard, error),
-        )
-    };
+    let (body, next) = try_eval!(cache, Lambda, start, parse_term(cache, tokens, next, error));
 
     // Construct and return the lambda.
     cache_return!(
@@ -870,15 +938,9 @@ fn parse_lambda<'a, 'b>(
         start,
         Some((
             Term {
-                source_range: if let ((start, _), Some((_, end))) =
-                    (tokens[start].source_range, body.source_range)
-                {
-                    Some((start, end))
-                } else {
-                    None
-                },
+                source_range: (tokens[start].source_range.0, body.source_range.1),
                 group: false,
-                variant: term::Variant::Lambda(variable, Rc::new(domain), Rc::new(body)),
+                variant: Variant::Lambda(variable, Rc::new(domain), Rc::new(body)),
             },
             next
         )),
@@ -890,8 +952,6 @@ fn parse_application<'a, 'b>(
     cache: &mut Cache<'a, 'b>,
     tokens: &'b [Token<'a>],
     start: usize,
-    depth: usize,
-    context: &mut HashMap<&'a str, usize>,
     error: &mut ParseError<'a, 'b>,
 ) -> CacheResult<'a, 'b> {
     // Check the cache and make sure we have some tokens to parse.
@@ -902,7 +962,7 @@ fn parse_application<'a, 'b>(
         cache,
         Application,
         start,
-        parse_applicand(cache, tokens, start, depth, context, error),
+        parse_applicand(cache, tokens, start, error),
     );
 
     // Parse the argument.
@@ -910,7 +970,7 @@ fn parse_application<'a, 'b>(
         cache,
         NonArrowTerm,
         start,
-        parse_non_arrow_term(cache, tokens, next, depth, context, error),
+        parse_non_arrow_term(cache, tokens, next, error),
     );
 
     // Construct and return the application.
@@ -920,15 +980,9 @@ fn parse_application<'a, 'b>(
         start,
         Some((
             Term {
-                source_range: if let (Some((start, _)), Some((_, end))) =
-                    (applicand.source_range, argument.source_range)
-                {
-                    Some((start, end))
-                } else {
-                    None
-                },
+                source_range: (applicand.source_range.0, argument.source_range.1),
                 group: false,
-                variant: term::Variant::Application(Rc::new(applicand), Rc::new(argument)),
+                variant: Variant::Application(Rc::new(applicand), Rc::new(argument)),
             },
             next,
         )),
@@ -940,8 +994,6 @@ fn parse_let<'a, 'b>(
     cache: &mut Cache<'a, 'b>,
     tokens: &'b [Token<'a>],
     start: usize,
-    depth: usize,
-    context: &mut HashMap<&'a str, usize>,
     error: &mut ParseError<'a, 'b>,
 ) -> CacheResult<'a, 'b> {
     // Check the cache and make sure we have some tokens to parse.
@@ -954,57 +1006,13 @@ fn parse_let<'a, 'b>(
     let next = consume_token!(cache, Let, start, tokens, Equals, next, error);
 
     // Parse the definition.
-    let (definition, next) = try_eval!(
-        cache,
-        Let,
-        start,
-        parse_term(cache, tokens, next, depth, context, error),
-    );
+    let (definition, next) = try_eval!(cache, Let, start, parse_term(cache, tokens, next, error),);
 
     // Consume the semicolon.
     let next = consume_token!(cache, Let, start, tokens, Semicolon, next, error);
 
-    // If the variable is `PLACEHOLDER_VARIABLE`, don't check for naming conflicts, and don't add
-    // it to the context.
-    if variable != PLACEHOLDER_VARIABLE {
-        // Fail if the variable is already in the context.
-        if context.contains_key(variable) {
-            if next > error.1 {
-                *error = (
-                    Some(Rc::new(move |source_path, source_contents| {
-                        throw(
-                            &format!("Variable {} already exists.", variable.code_str()),
-                            source_path,
-                            source_contents,
-                            tokens[start].source_range,
-                        )
-                    }) as ErrorFactory),
-                    next,
-                );
-            }
-
-            cache_return!(cache, Let, start, None);
-        }
-
-        // Add the variable to the context.
-        context.insert(variable, depth);
-    }
-
-    // Remove the variable from the context (if it was added) when the function returns.
-    let context_cell = RefCell::new(context);
-    defer! {{ context_cell.borrow_mut().remove(variable); }};
-
     // Parse the body.
-    let (body, next) = {
-        let mut guard = context_cell.borrow_mut();
-
-        try_eval!(
-            cache,
-            Let,
-            start,
-            parse_term(cache, tokens, next, depth + 1, &mut *guard, error),
-        )
-    };
+    let (body, next) = try_eval!(cache, Let, start, parse_term(cache, tokens, next, error));
 
     // Construct and return the let.
     cache_return!(
@@ -1013,15 +1021,9 @@ fn parse_let<'a, 'b>(
         start,
         Some((
             Term {
-                source_range: if let ((start, _), Some((_, end))) =
-                    (tokens[start].source_range, body.source_range)
-                {
-                    Some((start, end))
-                } else {
-                    None
-                },
+                source_range: (tokens[start].source_range.0, body.source_range.1),
                 group: false,
-                variant: term::Variant::Let(variable, Rc::new(definition), Rc::new(body)),
+                variant: Variant::Let(variable, Rc::new(definition), Rc::new(body)),
             },
             next
         )),
@@ -1033,8 +1035,6 @@ fn parse_group<'a, 'b>(
     cache: &mut Cache<'a, 'b>,
     tokens: &'b [Token<'a>],
     start: usize,
-    depth: usize,
-    context: &mut HashMap<&'a str, usize>,
     error: &mut ParseError<'a, 'b>,
 ) -> CacheResult<'a, 'b> {
     // Check the cache and make sure we have some tokens to parse.
@@ -1044,12 +1044,7 @@ fn parse_group<'a, 'b>(
     let next = consume_token!(cache, Group, start, tokens, LeftParen, start, error);
 
     // Parse the inner term.
-    let (term, next) = try_eval!(
-        cache,
-        Group,
-        start,
-        parse_term(cache, tokens, next, depth, context, error),
-    );
+    let (term, next) = try_eval!(cache, Group, start, parse_term(cache, tokens, next, error),);
 
     // Consume the right parenthesis.
     let next = consume_token!(cache, Group, start, tokens, RightParen, next, error);
@@ -1061,10 +1056,10 @@ fn parse_group<'a, 'b>(
         start,
         Some((
             Term {
-                source_range: Some((
+                source_range: (
                     tokens[start].source_range.0,
                     tokens[next - 1].source_range.1
-                )),
+                ),
                 group: true,
                 variant: term.variant,
             },
@@ -1078,27 +1073,20 @@ fn parse_applicand<'a, 'b>(
     cache: &mut Cache<'a, 'b>,
     tokens: &'b [Token<'a>],
     start: usize,
-    depth: usize,
-    context: &mut HashMap<&'a str, usize>,
     error: &mut ParseError<'a, 'b>,
 ) -> CacheResult<'a, 'b> {
     // Check the cache and make sure we have some tokens to parse.
     cache_check!(cache, Applicand, start, error);
 
     // Try to parse the type of all types.
-    try_return!(
-        cache,
-        Type,
-        start,
-        parse_type(cache, tokens, start, depth, context, error),
-    );
+    try_return!(cache, Type, start, parse_type(cache, tokens, start, error),);
 
     // Try to parse a variable.
     try_return!(
         cache,
         Applicand,
         start,
-        parse_variable(cache, tokens, start, depth, context, error),
+        parse_variable(cache, tokens, start, error),
     );
 
     // Try to parse a group.
@@ -1106,7 +1094,7 @@ fn parse_applicand<'a, 'b>(
         cache,
         Applicand,
         start,
-        parse_group(cache, tokens, start, depth, context, error),
+        parse_group(cache, tokens, start, error),
     );
 
     // If we made it this far, the parse failed.
@@ -1118,8 +1106,6 @@ fn parse_non_arrow_term<'a, 'b>(
     cache: &mut Cache<'a, 'b>,
     tokens: &'b [Token<'a>],
     start: usize,
-    depth: usize,
-    context: &mut HashMap<&'a str, usize>,
     error: &mut ParseError<'a, 'b>,
 ) -> CacheResult<'a, 'b> {
     // Check the cache and make sure we have some tokens to parse.
@@ -1130,23 +1116,18 @@ fn parse_non_arrow_term<'a, 'b>(
         cache,
         Application,
         start,
-        parse_application(cache, tokens, start, depth, context, error),
+        parse_application(cache, tokens, start, error),
     );
 
     // Try to parse the type of all types.
-    try_return!(
-        cache,
-        Type,
-        start,
-        parse_type(cache, tokens, start, depth, context, error),
-    );
+    try_return!(cache, Type, start, parse_type(cache, tokens, start, error),);
 
     // Try to parse a variable.
     try_return!(
         cache,
         NonArrowTerm,
         start,
-        parse_variable(cache, tokens, start, depth, context, error),
+        parse_variable(cache, tokens, start, error),
     );
 
     // Try to parse a group.
@@ -1154,7 +1135,7 @@ fn parse_non_arrow_term<'a, 'b>(
         cache,
         NonArrowTerm,
         start,
-        parse_group(cache, tokens, start, depth, context, error),
+        parse_group(cache, tokens, start, error),
     );
 
     // If we made it this far, the parse failed.
@@ -1196,7 +1177,6 @@ mod tests {
             parse(None, source, &tokens[..], &context[..]).unwrap(),
             Term {
                 source_range: Some((0, 1)),
-                group: false,
                 variant: Variable("x", 0),
             },
         );
@@ -1224,17 +1204,14 @@ mod tests {
             parse(None, source, &tokens[..], &context[..]).unwrap(),
             Term {
                 source_range: Some((0, 6)),
-                group: false,
                 variant: Pi(
                     "_",
                     Rc::new(Term {
                         source_range: Some((0, 1)),
-                        group: false,
                         variant: Variable("a", 1),
                     }),
                     Rc::new(Term {
                         source_range: Some((5, 6)),
-                        group: false,
                         variant: Variable("b", 1),
                     }),
                 ),
@@ -1252,27 +1229,22 @@ mod tests {
             parse(None, source, &tokens[..], &context[..]).unwrap(),
             Term {
                 source_range: Some((0, 11)),
-                group: false,
                 variant: Pi(
                     "_",
                     Rc::new(Term {
                         source_range: Some((0, 1)),
-                        group: false,
                         variant: Variable("a", 2),
                     }),
                     Rc::new(Term {
                         source_range: Some((5, 11)),
-                        group: false,
                         variant: Pi(
                             "_",
                             Rc::new(Term {
                                 source_range: Some((5, 6)),
-                                group: false,
                                 variant: Variable("b", 2),
                             }),
                             Rc::new(Term {
                                 source_range: Some((10, 11)),
-                                group: false,
                                 variant: Variable("c", 2),
                             }),
                         ),
@@ -1292,17 +1264,14 @@ mod tests {
             parse(None, source, &tokens[..], &context[..]).unwrap(),
             Term {
                 source_range: Some((0, 12)),
-                group: false,
                 variant: Pi(
                     "x",
                     Rc::new(Term {
                         source_range: Some((5, 6)),
-                        group: false,
                         variant: Variable("a", 0),
                     }),
                     Rc::new(Term {
                         source_range: Some((11, 12)),
-                        group: false,
                         variant: Variable("x", 0),
                     }),
                 ),
@@ -1332,27 +1301,22 @@ mod tests {
             parse(None, source, &tokens[..], &context[..]).unwrap(),
             Term {
                 source_range: Some((0, 23)),
-                group: false,
                 variant: Pi(
                     "_",
                     Rc::new(Term {
                         source_range: Some((5, 6)),
-                        group: false,
                         variant: Variable("a", 0),
                     }),
                     Rc::new(Term {
                         source_range: Some((11, 23)),
-                        group: false,
                         variant: Pi(
                             "_",
                             Rc::new(Term {
                                 source_range: Some((16, 17)),
-                                group: false,
                                 variant: Variable("a", 1),
                             }),
                             Rc::new(Term {
                                 source_range: Some((22, 23)),
-                                group: false,
                                 variant: Variable("a", 2),
                             }),
                         ),
@@ -1372,17 +1336,14 @@ mod tests {
             parse(None, source, &tokens[..], &context[..]).unwrap(),
             Term {
                 source_range: Some((0, 12)),
-                group: false,
                 variant: Lambda(
                     "x",
                     Rc::new(Term {
                         source_range: Some((5, 6)),
-                        group: false,
                         variant: Variable("a", 0),
                     }),
                     Rc::new(Term {
                         source_range: Some((11, 12)),
-                        group: false,
                         variant: Variable("x", 0),
                     }),
                 ),
@@ -1412,27 +1373,22 @@ mod tests {
             parse(None, source, &tokens[..], &context[..]).unwrap(),
             Term {
                 source_range: Some((0, 23)),
-                group: false,
                 variant: Lambda(
                     "_",
                     Rc::new(Term {
                         source_range: Some((5, 6)),
-                        group: false,
                         variant: Variable("a", 0),
                     }),
                     Rc::new(Term {
                         source_range: Some((11, 23)),
-                        group: false,
                         variant: Lambda(
                             "_",
                             Rc::new(Term {
                                 source_range: Some((16, 17)),
-                                group: false,
                                 variant: Variable("a", 1),
                             }),
                             Rc::new(Term {
                                 source_range: Some((22, 23)),
-                                group: false,
                                 variant: Variable("a", 2),
                             }),
                         ),
@@ -1452,16 +1408,13 @@ mod tests {
             parse(None, source, &tokens[..], &context[..]).unwrap(),
             Term {
                 source_range: Some((0, 3)),
-                group: true,
                 variant: Application(
                     Rc::new(Term {
                         source_range: Some((0, 1)),
-                        group: false,
                         variant: Variable("f", 1),
                     }),
                     Rc::new(Term {
                         source_range: Some((2, 3)),
-                        group: false,
                         variant: Variable("x", 0),
                     }),
                 ),
@@ -1479,27 +1432,22 @@ mod tests {
             parse(None, source, &tokens[..], &context[..]).unwrap(),
             Term {
                 source_range: Some((0, 5)),
-                group: true,
                 variant: Application(
                     Rc::new(Term {
                         source_range: Some((0, 3)),
-                        group: true,
                         variant: Application(
                             Rc::new(Term {
                                 source_range: Some((0, 1)),
-                                group: false,
                                 variant: Variable("f", 2),
                             }),
                             Rc::new(Term {
                                 source_range: Some((2, 3)),
-                                group: false,
                                 variant: Variable("x", 1),
                             }),
                         ),
                     }),
                     Rc::new(Term {
                         source_range: Some((4, 5)),
-                        group: false,
                         variant: Variable("y", 0),
                     }),
                 ),
@@ -1517,25 +1465,20 @@ mod tests {
             parse(None, source, &tokens[..], &context[..]).unwrap(),
             Term {
                 source_range: Some((0, 7)),
-                group: false,
                 variant: Application(
                     Rc::new(Term {
                         source_range: Some((0, 1)),
-                        group: false,
                         variant: Variable("f", 2),
                     }),
                     Rc::new(Term {
                         source_range: Some((3, 6)),
-                        group: true,
                         variant: Application(
                             Rc::new(Term {
                                 source_range: Some((3, 4)),
-                                group: false,
                                 variant: Variable("x", 1),
                             }),
                             Rc::new(Term {
                                 source_range: Some((5, 6)),
-                                group: false,
                                 variant: Variable("y", 0),
                             }),
                         ),
@@ -1555,17 +1498,14 @@ mod tests {
             parse(None, source, &tokens[..], &context[..]).unwrap(),
             Term {
                 source_range: Some((0, 8)),
-                group: false,
                 variant: Let(
                     "x",
                     Rc::new(Term {
                         source_range: Some((4, 5)),
-                        group: false,
                         variant: Variable("a", 0),
                     }),
                     Rc::new(Term {
                         source_range: Some((7, 8)),
-                        group: false,
                         variant: Variable("x", 0),
                     }),
                 ),
@@ -1583,7 +1523,6 @@ mod tests {
             parse(None, source, &tokens[..], &context[..]).unwrap(),
             Term {
                 source_range: Some((0, 3)),
-                group: true,
                 variant: Variable("x", 0),
             },
         );
@@ -1599,68 +1538,55 @@ mod tests {
             parse(None, source, &tokens[..], &context[..]).unwrap(),
             Term {
                 source_range: Some((0, 58)),
-                group: false,
                 variant: Lambda(
                     "a",
                     Rc::new(Term {
                         source_range: Some((5, 9)),
-                        group: false,
                         variant: Type,
                     }),
                     Rc::new(Term {
                         source_range: Some((14, 58)),
-                        group: false,
                         variant: Lambda(
                             "b",
                             Rc::new(Term {
                                 source_range: Some((19, 23)),
-                                group: false,
                                 variant: Type,
                             }),
                             Rc::new(Term {
                                 source_range: Some((28, 58)),
-                                group: false,
                                 variant: Lambda(
                                     "f",
                                     Rc::new(Term {
                                         source_range: Some((33, 39)),
-                                        group: false,
                                         variant: Pi(
                                             "_",
                                             Rc::new(Term {
                                                 source_range: Some((33, 34)),
-                                                group: false,
                                                 variant: Variable("a", 1),
                                             }),
                                             Rc::new(Term {
                                                 source_range: Some((38, 39)),
-                                                group: false,
                                                 variant: Variable("b", 1),
                                             }),
                                         ),
                                     }),
                                     Rc::new(Term {
                                         source_range: Some((44, 58)),
-                                        group: false,
                                         variant: Lambda(
                                             "x",
                                             Rc::new(Term {
                                                 source_range: Some((49, 50)),
-                                                group: false,
                                                 variant: Variable("a", 2),
                                             }),
                                             Rc::new(Term {
                                                 source_range: Some((55, 58)),
-                                                group: true,
                                                 variant: Application(
                                                     Rc::new(Term {
                                                         source_range: Some((55, 56)),
-                                                        group: false,
                                                         variant: Variable("f", 1),
                                                     }),
                                                     Rc::new(Term {
                                                         source_range: Some((57, 58)),
-                                                        group: false,
                                                         variant: Variable("x", 0),
                                                     }),
                                                 ),

--- a/src/term.rs
+++ b/src/term.rs
@@ -9,7 +9,6 @@ use std::{
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Term<'a> {
     pub source_range: Option<(usize, usize)>, // [start, end)
-    pub group: bool, // For an explanation of this field, see [ref:group-flag].
     pub variant: Variant<'a>,
 }
 
@@ -19,7 +18,7 @@ pub enum Variant<'a> {
     // This is the type of all types, including itself.
     Type,
 
-    // A variable is a placeholder bound by a lambda or a pi type. The integer is the De Bruijn
+    // A variable is a placeholder bound by a lambda, pi type, or let. The integer is the De Bruijn
     // index for the variable.
     Variable(&'a str, usize),
 
@@ -38,16 +37,7 @@ pub enum Variant<'a> {
 
 impl<'a> Display for Term<'a> {
     fn fmt(&self, f: &mut Formatter) -> Result {
-        if self.group {
-            write!(f, "(")?;
-        }
-
-        write!(f, "{}", self.variant)?;
-
-        if self.group {
-            write!(f, ")")?;
-        }
-
+        write!(f, "({})", self.variant)?;
         Ok(())
     }
 }
@@ -78,6 +68,5 @@ impl<'a> Display for Variant<'a> {
 // Construct the type of all types once here rather than constructing it many times later.
 pub const TYPE_TERM: Term = Term {
     source_range: None,
-    group: false,
     variant: Variant::Type,
 };

--- a/src/type_checker.rs
+++ b/src/type_checker.rs
@@ -28,19 +28,11 @@ pub fn type_check<'a>(
         Variable(_, index) => {
             // Look up the type in the context, and shift it such that it's valid in the
             // current context.
-            let shifted_type = shift(
+            shift(
                 typing_context[typing_context.len() - 1 - *index].clone(),
                 0,
                 *index + 1,
-            );
-
-            // Turn on the `group` flag to ensure it parses correctly in whatever term surrounds
-            // it.
-            Rc::new(Term {
-                source_range: shifted_type.source_range,
-                group: true,
-                variant: shifted_type.variant.clone(),
-            })
+            )
         }
         Lambda(variable, domain, body) => {
             // Infer the type of the domain.
@@ -105,7 +97,6 @@ pub fn type_check<'a>(
             // Construct and return the pi type.
             Rc::new(Term {
                 source_range: term.source_range,
-                group: true,
                 variant: Pi(variable, domain.clone(), codomain),
             })
         }
@@ -377,12 +368,10 @@ mod tests {
         let mut typing_context = vec![
             Rc::new(Term {
                 source_range: None,
-                group: false,
                 variant: Type,
             }),
             Rc::new(Term {
                 source_range: None,
-                group: false,
                 variant: Variable("a", 0),
             }),
         ];
@@ -412,7 +401,6 @@ mod tests {
         let parsing_context = ["a"];
         let mut typing_context = vec![Rc::new(Term {
             source_range: None,
-            group: false,
             variant: Type,
         })];
         let mut normalization_context = vec![None];
@@ -441,7 +429,6 @@ mod tests {
         let parsing_context = ["a"];
         let mut typing_context = vec![Rc::new(Term {
             source_range: None,
-            group: false,
             variant: Type,
         })];
         let mut normalization_context = vec![None];
@@ -471,12 +458,10 @@ mod tests {
         let mut typing_context = vec![
             Rc::new(Term {
                 source_range: None,
-                group: false,
                 variant: Type,
             }),
             Rc::new(Term {
                 source_range: None,
-                group: false,
                 variant: Variable("a", 0),
             }),
         ];
@@ -507,17 +492,14 @@ mod tests {
         let mut typing_context = vec![
             Rc::new(Term {
                 source_range: None,
-                group: false,
                 variant: Type,
             }),
             Rc::new(Term {
                 source_range: None,
-                group: false,
                 variant: Type,
             }),
             Rc::new(Term {
                 source_range: None,
-                group: false,
                 variant: Variable("b", 0),
             }),
         ];
@@ -535,7 +517,7 @@ mod tests {
                 &mut typing_context,
                 &mut normalization_context
             ),
-            "has type `(b)` when `a` was expected",
+            "has type `(b)` when `(a)` was expected",
         );
     }
 
@@ -545,12 +527,10 @@ mod tests {
         let mut typing_context = vec![
             Rc::new(Term {
                 source_range: None,
-                group: false,
                 variant: Type,
             }),
             Rc::new(Term {
                 source_range: None,
-                group: false,
                 variant: Variable("a", 0),
             }),
         ];
@@ -581,12 +561,10 @@ mod tests {
         let mut typing_context = vec![
             Rc::new(Term {
                 source_range: None,
-                group: false,
                 variant: Type,
             }),
             Rc::new(Term {
                 source_range: None,
-                group: false,
                 variant: Variable("int", 0),
             }),
         ];


### PR DESCRIPTION
Introduce an intermediate AST in preparation for mutually recursive let bindings. This change also has the nice side effect of removing the `group` field in terms, which is largely useless after parsing.