### PR TITLE
Allow line breaks to terminate definitions

### DIFF
--- a/examples/equality.g
+++ b/examples/equality.g
@@ -14,7 +14,7 @@
           p y) =>
 
 # A helper function to check the type of a term
-prove = (a : type) => (x : a) => x;
+prove = (a : type) => (x : a) => x
 
 # A proof that propositional equality is symmetric
 eq_symm = prove (
@@ -28,10 +28,10 @@ eq_symm = prove (
   (x : a) =>
   (y : a) =>
   (x_equals_y : eq a x y) =>
-    motive = (z : a) => eq a z x;
-    x_equals_x = refl a x;
+    motive = (z : a) => eq a z x
+    x_equals_x = refl a x
     eq_ind a x motive x_equals_x y x_equals_y
-);
+)
 
 # A proof that propositional equality is transitive
 eq_trans = prove (
@@ -49,9 +49,9 @@ eq_trans = prove (
   (z : a) =>
   (x_equals_y : eq a x y) =>
   (y_equals_z : eq a y z) =>
-    y_equals_x = eq_symm a x y x_equals_y;
-    motive = (w : a) => eq a w z;
+    y_equals_x = eq_symm a x y x_equals_y
+    motive = (w : a) => eq a w z
     eq_ind a y motive y_equals_z x y_equals_x
-);
+)
 
 type

--- a/examples/girard.g
+++ b/examples/girard.g
@@ -6,37 +6,33 @@
 #   and Applications (TLCA ’95). Springer-Verlag, Berlin, Heidelberg, 266–278.
 
 # The cast of characters in our story
-false = (p : type) -> p;
-negate = (phi : type) => phi -> false;
-power = (S : type) => S -> type;
-U = (X : type) -> ((power (power X) -> X) -> power (power X));
+false = (p : type) -> p
+negate = (phi : type) => phi -> false
+power = (S : type) => S -> type
+universe = (X : type) -> ((power (power X) -> X) -> power (power X))
 tau =
-  (t : power (power U)) =>
+  (t : power (power universe)) =>
     (X : type) =>
       (f : power (power X) -> X) =>
         (p : power X) =>
-          t ((x : U) => p (f (x X f)));
-sigma = (s : U) => s U ((t : power (power U)) => tau t);
-Delta = (y : U) => negate ((p : power U) -> sigma y p -> p (tau (sigma y)));
-Omega = tau ((p : power U) => (x : U) -> sigma x p -> p x);
+          t ((x : universe) => p (f (x X f)))
+sigma = (s : universe) => s universe ((t : power (power universe)) => tau t)
+delta = (y : universe) => negate ((p : power universe) -> sigma y p -> p (tau (sigma y)))
+omega = tau ((p : power universe) => (x : universe) -> sigma x p -> p x)
 
 # Let the fun begin!
 (
-  (zero : (p : power U) -> ((x : U) -> sigma x p -> p x) -> p Omega) =>
+  (zero : (p : power universe) -> ((x : universe) -> sigma x p -> p x) -> p omega) =>
     (
-      zero
-      Delta
-      (
-        (x : U) =>
-          (two : sigma x Delta) =>
-            (three : (p : power U) -> sigma x p -> p (tau (sigma x))) =>
-              three Delta two ((p : power U) => three ((y : U) => p (tau (sigma y))))
+      zero delta (
+        (x : universe) =>
+          (two : sigma x delta) =>
+            (three : (p : power universe) -> sigma x p -> p (tau (sigma x))) =>
+              three delta two ((p : power universe) => three ((y : universe) => p (tau (sigma y))))
       )
-    )
-    ((p : power U) => zero ((y : U) => p (tau (sigma y))))
-)
-(
-  (p : power U) =>
-    (one : (x : U) -> sigma x p -> p x) =>
-      one Omega ((x : U) => one (tau (sigma x)))
+    ) ((p : power universe) => zero ((y : universe) => p (tau (sigma y))))
+) (
+  (p : power universe) =>
+    (one : (x : universe) -> sigma x p -> p x) =>
+      one omega ((x : universe) => one (tau (sigma x)))
 )

--- a/examples/identity.g
+++ b/examples/identity.g
@@ -1,4 +1,4 @@
 # The polymorphic identity function
-id = (a : type) => (x : a) => x;
+id = (a : type) => (x : a) => x
 
 id type type

--- a/grammar.y
+++ b/grammar.y
@@ -23,9 +23,9 @@
 
 %token COLON
 %token EQUALS
-%token SEMICOLON
 %token LEFT_PAREN
 %token RIGHT_PAREN
+%token TERMINATOR
 %token THICK_ARROW
 %token THIN_ARROW
 %token TYPE
@@ -42,7 +42,7 @@ term:
   LEFT_PAREN IDENTIFIER COLON term RIGHT_PAREN THIN_ARROW term |
   LEFT_PAREN IDENTIFIER COLON term RIGHT_PAREN THICK_ARROW term |
   application |
-  IDENTIFIER EQUALS term SEMICOLON term |
+  IDENTIFIER EQUALS term TERMINATOR term |
   LEFT_PAREN term RIGHT_PAREN ;
 
 application:

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1008,8 +1008,8 @@ fn parse_let<'a, 'b>(
     // Parse the definition.
     let (definition, next) = try_eval!(cache, Let, start, parse_term(cache, tokens, next, error),);
 
-    // Consume the semicolon.
-    let next = consume_token!(cache, Let, start, tokens, Semicolon, next, error);
+    // Consume the terminator.
+    let next = consume_token!(cache, Let, start, tokens, Terminator, next, error);
 
     // Parse the body.
     let (body, next) = try_eval!(cache, Let, start, parse_term(cache, tokens, next, error));

--- a/src/token.rs
+++ b/src/token.rs
@@ -17,9 +17,9 @@ pub struct Token<'a> {
 pub enum Variant<'a> {
     Colon,
     Equals,
-    Semicolon,
     LeftParen,
     RightParen,
+    Terminator,
     ThickArrow,
     ThinArrow,
     Type,
@@ -37,9 +37,9 @@ impl<'a> Display for Variant<'a> {
         match self {
             Self::Colon => write!(f, ":"),
             Self::Equals => write!(f, "="),
-            Self::Semicolon => write!(f, ";"),
             Self::LeftParen => write!(f, "("),
             Self::RightParen => write!(f, ")"),
+            Self::Terminator => write!(f, "\\n"),
             Self::ThickArrow => write!(f, "=>"),
             Self::ThinArrow => write!(f, "->"),
             Self::Type => write!(f, "{}", TYPE_KEYWORD),

--- a/src/type_checker.rs
+++ b/src/type_checker.rs
@@ -570,11 +570,10 @@ mod tests {
         ];
         let mut normalization_context = vec![None, None];
         let term_source = "
-          ((a : type) => (P: (x : a) -> type) => (f : (x : a) -> P x) => (x : a) => f x)
-            (((t : type) => t) int)
-              ((x : int) => int)
-                ((x : int) => x)
-                  y
+          ((a : type) => (P: (x : a) -> type) => (f : (x : a) -> P x) => (x : a) => f x) (
+            ((t : type) => t) int) (
+              (x : int) => int) (
+                (x : int) => x) y
         ";
         let type_source = "(((x : int) => int) (y))";
 


### PR DESCRIPTION
Allow line breaks to terminate definitions (in addition to semicolons).