### PR TITLE
Fix a tokenization issue regarding semicolons being deleted

### DIFF
--- a/src/token.rs
+++ b/src/token.rs
@@ -39,7 +39,7 @@ impl<'a> Display for Variant<'a> {
             Self::Equals => write!(f, "="),
             Self::LeftParen => write!(f, "("),
             Self::RightParen => write!(f, ")"),
-            Self::Terminator => write!(f, "\\n"),
+            Self::Terminator => write!(f, ";"),
             Self::ThickArrow => write!(f, "=>"),
             Self::ThinArrow => write!(f, "->"),
             Self::Type => write!(f, "{}", TYPE_KEYWORD),

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -146,7 +146,9 @@ pub fn tokenize<'a>(
     let mut filtered_tokens = vec![];
     let mut tokens_iter = tokens.iter().peekable();
     while let Some(token) = tokens_iter.next() {
-        if token.variant == Variant::Terminator {
+        if token.variant == Variant::Terminator
+            && &source_contents[token.source_range.0..token.source_range.1] == "\n"
+        {
             if let Some(next_token) = tokens_iter.peek() {
                 if match next_token.variant {
                     Variant::Colon


### PR DESCRIPTION
Fix a tokenization issue regarding semicolons being deleted. The tokenizer should only delete terminators corresponding to line breaks (when appropriate), never semicolons.