### PR TITLE
Make the `Display` impl for `token::Variant` more correct

### DIFF
--- a/src/token.rs
+++ b/src/token.rs
@@ -39,7 +39,7 @@ impl<'a> Display for Variant<'a> {
             Self::Equals => write!(f, "="),
             Self::LeftParen => write!(f, "("),
             Self::RightParen => write!(f, ")"),
-            Self::Terminator => write!(f, ";"),
+            Self::Terminator => write!(f, "; or \\n"),
             Self::ThickArrow => write!(f, "=>"),
             Self::ThinArrow => write!(f, "->"),
             Self::Type => write!(f, "{}", TYPE_KEYWORD),


### PR DESCRIPTION
Make the `Display` impl for `token::Variant` more correct. As a follow up, we can make this more specific by recording whether separators are parsed from semicolons or line breaks. Unfortunately, that change would be slightly awkward, though, because we'd no longer be able to use the `consume_token!` macro as is for parsing separators (as it tries to match on `token::Variant::$variant` without any constructor args).