### PR TITLE
Distinguish between the two types of terminators for better error detection and reporting

### DIFF
--- a/src/token.rs
+++ b/src/token.rs
@@ -19,11 +19,19 @@ pub enum Variant<'a> {
     Equals,
     LeftParen,
     RightParen,
-    Terminator,
+    Terminator(TerminatorType),
     ThickArrow,
     ThinArrow,
     Type,
     Identifier(&'a str),
+}
+
+// A terminator can be a line break or a semicolon. Note that not every line break is parsed as a
+// terminator, however.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum TerminatorType {
+    LineBreak,
+    Semicolon,
 }
 
 impl<'a> Display for Token<'a> {
@@ -39,7 +47,8 @@ impl<'a> Display for Variant<'a> {
             Self::Equals => write!(f, "="),
             Self::LeftParen => write!(f, "("),
             Self::RightParen => write!(f, ")"),
-            Self::Terminator => write!(f, "; or \\n"),
+            Self::Terminator(TerminatorType::LineBreak) => write!(f, "\\n"),
+            Self::Terminator(TerminatorType::Semicolon) => write!(f, ";"),
             Self::ThickArrow => write!(f, "=>"),
             Self::ThinArrow => write!(f, "->"),
             Self::Type => write!(f, "{}", TYPE_KEYWORD),


### PR DESCRIPTION
Distinguish between the two types of terminators for better error detection and reporting.

This is a breaking change. Previously this was allowed:

```gram
x = type;
x
```

But now it is forbidden because the semicolon and line break are redundant:

```gram
Error in main.g: Unexpected \n.

1 | x = type;
```