### PR TITLE
Remove a redundant call to `about(...)`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,6 @@ fn cli<'a, 'b>() -> App<'a, 'b> {
     App::new("Gram")
         .version(VERSION)
         .version_short("v")
-        .about("")
         .about(
             " \
              Gram is programming language for distributed systems. Visit https://www.gram.org for \


### PR DESCRIPTION
Remove a redundant call to `about(...)`. I'm surprised this existed for so long without being noticed!