### PR TITLE
Use underscores rather than hyphens to separate words in tags

### DIFF
--- a/grammar.y
+++ b/grammar.y
@@ -6,7 +6,7 @@
   Application is right-associative in this grammar to avoid left-recursion, since packrat parsers
   can't handle left-recursion. Note however that non-grouped applications are re-associated to the
   left in a post-processing step, because left-associative application gives better ergonomics for
-  currying. See [ref:reassociate-applications] for details.
+  currying. See [ref:reassociate_applications] for details.
 */
 
 /*

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,7 @@ fn cli<'a, 'b>() -> App<'a, 'b> {
                     Arg::with_name(RUN_SUBCOMMAND_PATH_OPTION)
                         .value_name("PATH")
                         .help("Sets the path of the program entrypoint")
-                        .required(true) // [tag:run-subcommand-shell-required]
+                        .required(true) // [tag:run_subcommand_shell_required]
                         .takes_value(true)
                         .number_of_values(1),
                 ),
@@ -86,7 +86,7 @@ fn cli<'a, 'b>() -> App<'a, 'b> {
                     Arg::with_name(SHELL_COMPLETION_SUBCOMMAND_SHELL_OPTION)
                         .value_name("SHELL")
                         .help("Bash, Fish, Zsh, PowerShell, or Elvish")
-                        .required(true) // [tag:shell-completion-subcommand-shell-required]
+                        .required(true) // [tag:shell_completion_subcommand_shell_required]
                         .takes_value(true)
                         .number_of_values(1),
                 ),
@@ -171,29 +171,29 @@ fn entry() -> Result<(), Error> {
     } else {
         // Decide what to do based on the subcommand.
         match matches.subcommand_name() {
-            // [tag:run-subcommand]
+            // [tag:run_subcommand]
             Some(subcommand) if subcommand == RUN_SUBCOMMAND => {
                 // Determine the path to the source file.
                 let source_path = Path::new(
                     matches
                         .subcommand_matches(RUN_SUBCOMMAND)
-                        .unwrap() // [ref:run-subcommand]
+                        .unwrap() // [ref:run_subcommand]
                         .value_of(RUN_SUBCOMMAND_PATH_OPTION)
-                        .unwrap(), // [ref:run-subcommand-shell-required]
+                        .unwrap(), // [ref:run_subcommand_shell_required]
                 );
 
                 // Run the program.
                 run(source_path)?;
             }
 
-            // [tag:shell-completion-subcommand]
+            // [tag:shell_completion_subcommand]
             Some(subcommand) if subcommand == SHELL_COMPLETION_SUBCOMMAND => {
                 shell_completion(
                     matches
                         .subcommand_matches(SHELL_COMPLETION_SUBCOMMAND)
-                        .unwrap() // [ref:shell-completion-subcommand]
+                        .unwrap() // [ref:shell_completion_subcommand]
                         .value_of(SHELL_COMPLETION_SUBCOMMAND_SHELL_OPTION)
-                        .unwrap(), // [ref:shell-completion-subcommand-shell-required]
+                        .unwrap(), // [ref:shell_completion_subcommand_shell_required]
                 )?;
             }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -22,11 +22,11 @@ use std::{cell::RefCell, collections::HashMap, path::Path, rc::Rc};
 // is the natural choice to make currying ergonomic. However, this reinforces the left-recursion
 // problem (1). To resolve this, we employ a trick: we parse applications as right-associative, but
 // then we reassociate them in a post-processing step to achieve the desired left-associativity
-// [tag:reassociate-applications]. For example, we parse `f x y` as `f [x y]`, then transform it
+// [tag:reassociate_applications]. For example, we parse `f x y` as `f [x y]`, then transform it
 // into `[f x] y`. We have to be careful not to reassociate applications in which the
 // associativity has already been specified by explicit grouping. For example, we should not
 // reassociate `f (x y)`. Thus, when parsing, we record whether a term was parsed as group
-// [tag:group-flag].
+// [tag:group_flag].
 //
 // After resolving ambiguities, we end up with the grammar located in `grammar.y`. This grammar has
 // been verified to be unambiguous by Bison. [tag:grammar] [ref:bison_grammar]
@@ -43,11 +43,11 @@ pub const PLACEHOLDER_VARIABLE: &str = "_";
 // The token stream is parsed into an abstract syntax tree (AST). This struct represents a node in
 // an AST. This is similar to `term::Term`, except:
 // - It doesn't contain De Bruijn indices.
-// - It has a `group` field (see see [ref:group-flag]).
+// - It has a `group` field (see see [ref:group_flag]).
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Term<'a> {
     pub source_range: (usize, usize), // [start, end)
-    pub group: bool,                  // For an explanation of this field, see [ref:group-flag].
+    pub group: bool,                  // For an explanation of this field, see [ref:group_flag].
     pub variant: Variant<'a>,
 }
 

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -54,7 +54,7 @@ pub fn tokenize<'a>(
                 });
             }
             '\n' => {
-                // [tag:line-break] [tag:tokens_nonempty]
+                // [tag:line_break] [tag:tokens_nonempty]
                 if !tokens.is_empty()
                     && match tokens.last().unwrap().variant /* [ref:tokens_nonempty] */ {
                         Variant::Colon
@@ -118,10 +118,10 @@ pub fn tokenize<'a>(
                 }
             }
 
-            // Skip whitespace. Note that line breaks are handled above [ref:line-break].
+            // Skip whitespace. Note that line breaks are handled above [ref:line_break].
             _ if c.is_whitespace() => continue,
 
-            // Skip comments. Don't skip the terminating line break, if it exists [ref:line-break].
+            // Skip comments. Don't skip the terminating line break, if it exists [ref:line_break].
             '#' => {
                 while let Some((j, _)) = iter.next() {
                     if iter.peek() == Some(&(j + 1, '\n')) {


### PR DESCRIPTION
Use underscores rather than hyphens to separate words in tags. Previously, we were inconsistent!