### PR TITLE
Make the `bison` command more useful in the case when there is an issue with the grammar

### DIFF
--- a/toast.yml
+++ b/toast.yml
@@ -97,7 +97,8 @@ tasks:
       cargo fmt --all -- --check
       tagref
       shellcheck install.sh
-      bison --warnings=all -Werror grammar.y && rm grammar.tab.c
+      bison --verbose --report=itemset --report=lookahead --warnings=all -Werror grammar.y
+      rm grammar.output grammar.tab.c
 
   run:
     dependencies:


### PR DESCRIPTION
Make the `bison` command more useful in the case when there is an issue with the grammar. Now you can run `toast lint --shell` and then `cat grammar.output` to inspect the automaton.