### PR TITLE
Instead of attempting to maintain some kind of logical ordering of the tokens, just sort them lexicographically

### DIFF
--- a/src/token.rs
+++ b/src/token.rs
@@ -21,15 +21,15 @@ pub struct Token<'a> {
 pub enum Variant<'a> {
     Colon,
     Equals,
+    Identifier(&'a str),
+    Integer,
+    IntegerLiteral(BigInt),
     LeftParen,
     RightParen,
     Terminator(TerminatorType),
     ThickArrow,
     ThinArrow,
     Type,
-    Identifier(&'a str),
-    Integer,
-    IntegerLiteral(BigInt),
 }
 
 // A terminator can be a line break or a semicolon. Note that not every line break is parsed as a
@@ -51,6 +51,9 @@ impl<'a> Display for Variant<'a> {
         match self {
             Self::Colon => write!(f, ":"),
             Self::Equals => write!(f, "="),
+            Self::Identifier(name) => write!(f, "{}", name),
+            Self::Integer => write!(f, "{}", INTEGER_KEYWORD),
+            Self::IntegerLiteral(integer) => write!(f, "{}", integer),
             Self::LeftParen => write!(f, "("),
             Self::RightParen => write!(f, ")"),
             Self::Terminator(TerminatorType::LineBreak) => write!(f, "\\n"),
@@ -58,9 +61,6 @@ impl<'a> Display for Variant<'a> {
             Self::ThickArrow => write!(f, "=>"),
             Self::ThinArrow => write!(f, "->"),
             Self::Type => write!(f, "{}", TYPE_KEYWORD),
-            Self::Identifier(name) => write!(f, "{}", name),
-            Self::Integer => write!(f, "{}", INTEGER_KEYWORD),
-            Self::IntegerLiteral(integer) => write!(f, "{}", integer),
         }
     }
 }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -258,6 +258,61 @@ mod tests {
     }
 
     #[test]
+    fn tokenize_identifier() {
+        assert_eq!(
+            tokenize(None, "\u{5e78}\u{798f}").unwrap(),
+            vec![Token {
+                source_range: (0, 6),
+                variant: Variant::Identifier("\u{5e78}\u{798f}"),
+            }],
+        );
+    }
+
+    #[test]
+    fn tokenize_integer() {
+        assert_eq!(
+            tokenize(None, INTEGER_KEYWORD).unwrap(),
+            vec![Token {
+                source_range: (0, INTEGER_KEYWORD.len()),
+                variant: Variant::Integer,
+            }],
+        );
+    }
+
+    #[test]
+    fn tokenize_integer_literal() {
+        assert_eq!(
+            tokenize(None, "42").unwrap(),
+            vec![Token {
+                source_range: (0, 2),
+                variant: Variant::IntegerLiteral(ToBigInt::to_bigint(&42).unwrap()),
+            }],
+        );
+    }
+
+    #[test]
+    fn tokenize_left_paren() {
+        assert_eq!(
+            tokenize(None, "(").unwrap(),
+            vec![Token {
+                source_range: (0, 1),
+                variant: Variant::LeftParen,
+            }],
+        );
+    }
+
+    #[test]
+    fn tokenize_right_paren() {
+        assert_eq!(
+            tokenize(None, ")").unwrap(),
+            vec![Token {
+                source_range: (0, 1),
+                variant: Variant::RightParen,
+            }],
+        );
+    }
+
+    #[test]
     fn tokenize_terminator_line_break() {
         assert_eq!(
             tokenize(None, "\n\ntype\n\ntype\n\n").unwrap(),
@@ -320,28 +375,6 @@ mod tests {
     }
 
     #[test]
-    fn tokenize_left_paren() {
-        assert_eq!(
-            tokenize(None, "(").unwrap(),
-            vec![Token {
-                source_range: (0, 1),
-                variant: Variant::LeftParen,
-            }],
-        );
-    }
-
-    #[test]
-    fn tokenize_right_paren() {
-        assert_eq!(
-            tokenize(None, ")").unwrap(),
-            vec![Token {
-                source_range: (0, 1),
-                variant: Variant::RightParen,
-            }],
-        );
-    }
-
-    #[test]
     fn tokenize_thick_arrow() {
         assert_eq!(
             tokenize(None, "=>").unwrap(),
@@ -370,39 +403,6 @@ mod tests {
             vec![Token {
                 source_range: (0, TYPE_KEYWORD.len()),
                 variant: Variant::Type,
-            }],
-        );
-    }
-
-    #[test]
-    fn tokenize_integer() {
-        assert_eq!(
-            tokenize(None, INTEGER_KEYWORD).unwrap(),
-            vec![Token {
-                source_range: (0, INTEGER_KEYWORD.len()),
-                variant: Variant::Integer,
-            }],
-        );
-    }
-
-    #[test]
-    fn tokenize_identifier() {
-        assert_eq!(
-            tokenize(None, "\u{5e78}\u{798f}").unwrap(),
-            vec![Token {
-                source_range: (0, 6),
-                variant: Variant::Identifier("\u{5e78}\u{798f}"),
-            }],
-        );
-    }
-
-    #[test]
-    fn tokenize_integer_literal() {
-        assert_eq!(
-            tokenize(None, "42").unwrap(),
-            vec![Token {
-                source_range: (0, 2),
-                variant: Variant::IntegerLiteral(ToBigInt::to_bigint(&42).unwrap()),
             }],
         );
     }


### PR DESCRIPTION
Instead of attempting to maintain some kind of logical ordering of the tokens, just sort them lexicographically.