### PR TITLE
Make `evaluate` return a `Result` instead of potentially panicking

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -122,7 +122,7 @@ fn run(source_path: &Path) -> Result<(), Error> {
     println!("# Type:\n\n{}\n", term_type.to_string().code_str());
 
     // Evaluate the term.
-    let value = evaluate(Rc::new(term));
+    let value = evaluate(Rc::new(term))?;
     println!("# Value:\n\n{}", value.to_string().code_str());
 
     // If we made it this far, nothing went wrong.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1569,7 +1569,7 @@ fn parse_sum<'a, 'b>(
     );
 
     // Consume the plus symbol.
-    let next = consume_token!(cache, Sum, start, tokens, Plus, next, error, Low,);
+    let next = consume_token!(cache, Sum, start, tokens, Plus, next, error, Low);
 
     // Parse the right summand.
     let (summand2, next) = {
@@ -1616,7 +1616,7 @@ fn parse_difference<'a, 'b>(
     );
 
     // Consume the plus symbol.
-    let next = consume_token!(cache, Difference, start, tokens, Minus, next, error, Low,);
+    let next = consume_token!(cache, Difference, start, tokens, Minus, next, error, Low);
 
     // Parse the subtrahend.
     let (subtrahend, next) = {


### PR DESCRIPTION
Make `evaluate` return a `Result` instead of potentially panicking.

This is in preparation for the introduction of a partial function: integer division.