### PR TITLE
Enforce trailing commas

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,29 +42,27 @@ We are fortunate to have good tooling around enforcing a consistent style throug
 
 ### Trailing commas
 
-At the time of this writing, `cargo fmt` cannot enforce a convention regarding trailing commas.
-
-**Rule:** Always use trailing commas for sequences spanning multiple lines, such as in the following example:
-
-```rust
-foo(
-    bar,
-    baz,
-    qux,
-);
-```
-
-**Rule:** Do not use trailing commas for sequences spanning only a single line. For example:
-
-```rust
-foo(bar, baz, qux);
-```
+The linter enforces that items in multi-line sequences (e.g., function arguments and macro arguments) have trailing commas.
 
 **Rule:** Macros should be written to accept trailing commas as follows:
 
 ```rust
 macro_rules! my_macro {
     ($foo:expr, $bar:expr, $baz:expr $(,)?) => {{
+        ...
+    }};
+}
+```
+
+When the arguments in the definition of the macro span multiple lines, you will need a comment with a trailing comma to satisfy the linter as follows:
+
+```rust
+macro_rules! my_macro {
+    (
+        $foo:expr,
+        $bar:expr,
+        $baz:expr $(,)? // This comma is needed to satisfy the trailing commas check: ,
+    ) => {{
         ...
     }};
 }

--- a/src/equality.rs
+++ b/src/equality.rs
@@ -847,7 +847,7 @@ mod tests {
 
         assert_eq!(
             definitionally_equal(Rc::new(term1), Rc::new(term2), &mut definitions_context),
-            true
+            true,
         );
     }
 
@@ -866,7 +866,7 @@ mod tests {
 
         assert_eq!(
             definitionally_equal(Rc::new(term1), Rc::new(term2), &mut definitions_context),
-            true
+            true,
         );
     }
 
@@ -885,7 +885,7 @@ mod tests {
 
         assert_eq!(
             definitionally_equal(Rc::new(term1), Rc::new(term2), &mut definitions_context),
-            false
+            false,
         );
     }
 
@@ -904,7 +904,7 @@ mod tests {
 
         assert_eq!(
             definitionally_equal(Rc::new(term1), Rc::new(term2), &mut definitions_context),
-            true
+            true,
         );
     }
 
@@ -923,7 +923,7 @@ mod tests {
 
         assert_eq!(
             definitionally_equal(Rc::new(term1), Rc::new(term2), &mut definitions_context),
-            true
+            true,
         );
     }
 
@@ -942,7 +942,7 @@ mod tests {
 
         assert_eq!(
             definitionally_equal(Rc::new(term1), Rc::new(term2), &mut definitions_context),
-            false
+            false,
         );
     }
 
@@ -961,7 +961,7 @@ mod tests {
 
         assert_eq!(
             definitionally_equal(Rc::new(term1), Rc::new(term2), &mut definitions_context),
-            true
+            true,
         );
     }
 
@@ -980,7 +980,7 @@ mod tests {
 
         assert_eq!(
             definitionally_equal(Rc::new(term1), Rc::new(term2), &mut definitions_context),
-            false
+            false,
         );
     }
 
@@ -999,7 +999,7 @@ mod tests {
 
         assert_eq!(
             definitionally_equal(Rc::new(term1), Rc::new(term2), &mut definitions_context),
-            false
+            false,
         );
     }
 
@@ -1018,7 +1018,7 @@ mod tests {
 
         assert_eq!(
             definitionally_equal(Rc::new(term1), Rc::new(term2), &mut definitions_context),
-            true
+            true,
         );
     }
 
@@ -1037,7 +1037,7 @@ mod tests {
 
         assert_eq!(
             definitionally_equal(Rc::new(term1), Rc::new(term2), &mut definitions_context),
-            false
+            false,
         );
     }
 
@@ -1056,7 +1056,7 @@ mod tests {
 
         assert_eq!(
             definitionally_equal(Rc::new(term1), Rc::new(term2), &mut definitions_context),
-            false
+            false,
         );
     }
 
@@ -1075,7 +1075,7 @@ mod tests {
 
         assert_eq!(
             definitionally_equal(Rc::new(term1), Rc::new(term2), &mut definitions_context),
-            true
+            true,
         );
     }
 
@@ -1094,7 +1094,7 @@ mod tests {
 
         assert_eq!(
             definitionally_equal(Rc::new(term1), Rc::new(term2), &mut definitions_context),
-            false
+            false,
         );
     }
 
@@ -1113,7 +1113,7 @@ mod tests {
 
         assert_eq!(
             definitionally_equal(Rc::new(term1), Rc::new(term2), &mut definitions_context),
-            false
+            false,
         );
     }
 
@@ -1132,7 +1132,7 @@ mod tests {
 
         assert_eq!(
             definitionally_equal(Rc::new(term1), Rc::new(term2), &mut definitions_context),
-            true
+            true,
         );
     }
 
@@ -1151,7 +1151,7 @@ mod tests {
 
         assert_eq!(
             definitionally_equal(Rc::new(term1), Rc::new(term2), &mut definitions_context),
-            true
+            true,
         );
     }
 
@@ -1170,7 +1170,7 @@ mod tests {
 
         assert_eq!(
             definitionally_equal(Rc::new(term1), Rc::new(term2), &mut definitions_context),
-            false
+            false,
         );
     }
 
@@ -1189,7 +1189,7 @@ mod tests {
 
         assert_eq!(
             definitionally_equal(Rc::new(term1), Rc::new(term2), &mut definitions_context),
-            true
+            true,
         );
     }
 
@@ -1208,7 +1208,7 @@ mod tests {
 
         assert_eq!(
             definitionally_equal(Rc::new(term1), Rc::new(term2), &mut definitions_context),
-            false
+            false,
         );
     }
 
@@ -1227,7 +1227,7 @@ mod tests {
 
         assert_eq!(
             definitionally_equal(Rc::new(term1), Rc::new(term2), &mut definitions_context),
-            true
+            true,
         );
     }
 
@@ -1246,7 +1246,7 @@ mod tests {
 
         assert_eq!(
             definitionally_equal(Rc::new(term1), Rc::new(term2), &mut definitions_context),
-            false
+            false,
         );
     }
 
@@ -1265,7 +1265,7 @@ mod tests {
 
         assert_eq!(
             definitionally_equal(Rc::new(term1), Rc::new(term2), &mut definitions_context),
-            true
+            true,
         );
     }
 
@@ -1284,7 +1284,7 @@ mod tests {
 
         assert_eq!(
             definitionally_equal(Rc::new(term1), Rc::new(term2), &mut definitions_context),
-            false
+            false,
         );
     }
 
@@ -1303,7 +1303,7 @@ mod tests {
 
         assert_eq!(
             definitionally_equal(Rc::new(term1), Rc::new(term2), &mut definitions_context),
-            true
+            true,
         );
     }
 
@@ -1322,7 +1322,7 @@ mod tests {
 
         assert_eq!(
             definitionally_equal(Rc::new(term1), Rc::new(term2), &mut definitions_context),
-            false
+            false,
         );
     }
 
@@ -1341,7 +1341,7 @@ mod tests {
 
         assert_eq!(
             definitionally_equal(Rc::new(term1), Rc::new(term2), &mut definitions_context),
-            true
+            true,
         );
     }
 
@@ -1360,7 +1360,7 @@ mod tests {
 
         assert_eq!(
             definitionally_equal(Rc::new(term1), Rc::new(term2), &mut definitions_context),
-            true
+            true,
         );
     }
 
@@ -1379,7 +1379,7 @@ mod tests {
 
         assert_eq!(
             definitionally_equal(Rc::new(term1), Rc::new(term2), &mut definitions_context),
-            true
+            true,
         );
     }
 
@@ -1398,7 +1398,7 @@ mod tests {
 
         assert_eq!(
             definitionally_equal(Rc::new(term1), Rc::new(term2), &mut definitions_context),
-            true
+            true,
         );
     }
 
@@ -1417,7 +1417,7 @@ mod tests {
 
         assert_eq!(
             definitionally_equal(Rc::new(term1), Rc::new(term2), &mut definitions_context),
-            true
+            true,
         );
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,7 +36,9 @@ pub fn throw(
     message: &str,
     source_path: Option<&Path>,
     source_contents: &str,
-    source_range: (usize, usize), // [start, end)
+
+    // Inclusive on the left and exclusive on the right
+    source_range: (usize, usize),
 ) -> Error {
     {
         // Remember the relevant lines and the position of the start of the next line.
@@ -184,7 +186,7 @@ mod tests {
 
         assert_eq!(
             error.message,
-            "Error in `foo.g`: An error occurred.".to_owned()
+            "Error in `foo.g`: An error occurred.".to_owned(),
         );
     }
 
@@ -196,7 +198,7 @@ mod tests {
 
         assert_eq!(
             error.message,
-            "Error: An error occurred.\n\n1 | foo".to_owned()
+            "Error: An error occurred.\n\n1 | foo".to_owned(),
         );
     }
 
@@ -213,7 +215,7 @@ mod tests {
 
         assert_eq!(
             error.message,
-            "Error in `foo.g`: An error occurred.\n\n1 | foo".to_owned()
+            "Error in `foo.g`: An error occurred.\n\n1 | foo".to_owned(),
         );
     }
 
@@ -225,7 +227,7 @@ mod tests {
 
         assert_eq!(
             error.message,
-            "Error: An error occurred.\n\n1 | foo\n2 | bar\n3 | baz".to_owned()
+            "Error: An error occurred.\n\n1 | foo\n2 | bar\n3 | baz".to_owned(),
         );
     }
 
@@ -237,7 +239,7 @@ mod tests {
 
         assert_eq!(
             error.message,
-            "Error: An error occurred.\n\n2 | bar\n3 | baz".to_owned()
+            "Error: An error occurred.\n\n2 | bar\n3 | baz".to_owned(),
         );
     }
 
@@ -254,7 +256,7 @@ mod tests {
 
         assert_eq!(
             error.message,
-            "Error: An error occurred.\n\n 9 | foo\n10 | bar\n11 | baz".to_owned()
+            "Error: An error occurred.\n\n 9 | foo\n10 | bar\n11 | baz".to_owned(),
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,7 +178,8 @@ fn entry() -> Result<(), Error> {
                         .subcommand_matches(RUN_SUBCOMMAND)
                         .unwrap() // [ref:run_subcommand]
                         .value_of(RUN_SUBCOMMAND_PATH_OPTION)
-                        .unwrap(), // [ref:run_subcommand_shell_required]
+                        // [ref:run_subcommand_shell_required]
+                        .unwrap(),
                 );
 
                 // Run the program.
@@ -192,7 +193,8 @@ fn entry() -> Result<(), Error> {
                         .subcommand_matches(SHELL_COMPLETION_SUBCOMMAND)
                         .unwrap() // [ref:shell_completion_subcommand]
                         .value_of(SHELL_COMPLETION_SUBCOMMAND_SHELL_OPTION)
-                        .unwrap(), // [ref:shell_completion_subcommand_shell_required]
+                        // [ref:shell_completion_subcommand_shell_required]
+                        .unwrap(),
                 )?;
             }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -55,8 +55,10 @@ pub const PLACEHOLDER_VARIABLE: &str = "_";
 // - It has source ranges for variables.
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct Term<'a> {
-    source_range: (usize, usize), // [start, end)
-    group: bool,                  // For an explanation of this field, see [ref:group_flag].
+    // Inclusive on the left and exclusive on the right
+    source_range: (usize, usize),
+
+    group: bool, // For an explanation of this field, see [ref:group_flag].
     variant: Variant<'a>,
 }
 
@@ -95,7 +97,9 @@ enum Variant<'a> {
 // us to report nice errors when there are multiple variables with the same name.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct SourceVariable<'a> {
-    source_range: (usize, usize), // [start, end)
+    // Inclusive on the left and exclusive on the right
+    source_range: (usize, usize),
+
     name: &'a str,
 }
 
@@ -254,7 +258,7 @@ macro_rules! consume_token {
         $variant:ident,
         $next:expr,
         $error:ident,
-        $confidence:ident $(,)?
+        $confidence:ident $(,)? // This comma is needed to satisfy the trailing commas check: ,
     ) => {{
         // Macros are call-by-name, but we want call-by-value (or at least call-by-need) to avoid
         // accidentally evaluating arguments multiple times. Here we force eager evaluation.
@@ -327,7 +331,7 @@ macro_rules! consume_terminator {
         $tokens:expr,
         $next:expr,
         $error:ident,
-        $confidence:ident $(,)?
+        $confidence:ident $(,)? // This comma is needed to satisfy the trailing commas check: ,
     ) => {{
         // Macros are call-by-name, but we want call-by-value (or at least call-by-need) to avoid
         // accidentally evaluating arguments multiple times. Here we force eager evaluation.
@@ -403,7 +407,7 @@ macro_rules! consume_identifier {
         $tokens:expr,
         $next:expr,
         $error:ident,
-        $confidence:ident $(,)?
+        $confidence:ident $(,)? // This comma is needed to satisfy the trailing commas check: ,
     ) => {{
         // Macros are call-by-name, but we want call-by-value (or at least call-by-need) to avoid
         // accidentally evaluating arguments multiple times. Here we force eager evaluation.
@@ -1846,7 +1850,7 @@ fn parse_term<'a, 'b>(
         cache,
         Term,
         start,
-        parse_jumbo_term(cache, tokens, start, error)
+        parse_jumbo_term(cache, tokens, start, error),
     );
 
     // If we made it this far, the parse failed. If none of the parse attempts resulted in a high-
@@ -1943,7 +1947,7 @@ fn parse_lambda<'a, 'b>(
         cache,
         Lambda,
         start,
-        parse_jumbo_term(cache, tokens, next, error)
+        parse_jumbo_term(cache, tokens, next, error),
     );
 
     // Consume the right parenthesis.
@@ -2002,7 +2006,7 @@ fn parse_pi<'a, 'b>(
         cache,
         Pi,
         start,
-        parse_jumbo_term(cache, tokens, next, error)
+        parse_jumbo_term(cache, tokens, next, error),
     );
 
     // Consume the right parenthesis.
@@ -2102,7 +2106,7 @@ fn parse_non_dependent_pi<'a, 'b>(
                     Rc::new(codomain),
                 ),
             },
-            next
+            next,
         )),
     )
 }
@@ -2122,7 +2126,7 @@ fn parse_application<'a, 'b>(
         cache,
         Application,
         start,
-        parse_atom(cache, tokens, start, error)
+        parse_atom(cache, tokens, start, error),
     );
 
     // Parse the argument.
@@ -2173,7 +2177,7 @@ fn parse_let<'a, 'b>(
                 cache,
                 Let,
                 start,
-                parse_small_term(cache, tokens, next, error)
+                parse_small_term(cache, tokens, next, error),
             );
 
             // Package up the annotation in the right form.
@@ -2368,7 +2372,7 @@ fn parse_sum<'a, 'b>(
                 group: false,
                 variant: Variant::Sum(Rc::new(summand1), Rc::new(summand2)),
             },
-            next
+            next,
         )),
     )
 }
@@ -2415,7 +2419,7 @@ fn parse_difference<'a, 'b>(
                 group: false,
                 variant: Variant::Difference(Rc::new(minuend), Rc::new(subtrahend)),
             },
-            next
+            next,
         )),
     )
 }
@@ -2462,7 +2466,7 @@ fn parse_product<'a, 'b>(
                 group: false,
                 variant: Variant::Product(Rc::new(factor1), Rc::new(factor2)),
             },
-            next
+            next,
         )),
     )
 }
@@ -2509,7 +2513,7 @@ fn parse_quotient<'a, 'b>(
                 group: false,
                 variant: Variant::Quotient(Rc::new(dividend), Rc::new(divisor)),
             },
-            next
+            next,
         )),
     )
 }
@@ -2556,7 +2560,7 @@ fn parse_less_than<'a, 'b>(
                 group: false,
                 variant: Variant::LessThan(Rc::new(term1), Rc::new(term2)),
             },
-            next
+            next,
         )),
     )
 }
@@ -2588,7 +2592,7 @@ fn parse_less_than_or_equal_to<'a, 'b>(
         LessThanOrEqualTo,
         next,
         error,
-        Low
+        Low,
     );
 
     // Parse the right term.
@@ -2612,7 +2616,7 @@ fn parse_less_than_or_equal_to<'a, 'b>(
                 group: false,
                 variant: Variant::LessThanOrEqualTo(Rc::new(term1), Rc::new(term2)),
             },
-            next
+            next,
         )),
     )
 }
@@ -2644,7 +2648,7 @@ fn parse_equal_to<'a, 'b>(
         DoubleEquals,
         next,
         error,
-        Low
+        Low,
     );
 
     // Parse the right term.
@@ -2668,7 +2672,7 @@ fn parse_equal_to<'a, 'b>(
                 group: false,
                 variant: Variant::EqualTo(Rc::new(term1), Rc::new(term2)),
             },
-            next
+            next,
         )),
     )
 }
@@ -2700,7 +2704,7 @@ fn parse_greater_than<'a, 'b>(
         GreaterThan,
         next,
         error,
-        Low
+        Low,
     );
 
     // Parse the right term.
@@ -2724,7 +2728,7 @@ fn parse_greater_than<'a, 'b>(
                 group: false,
                 variant: Variant::GreaterThan(Rc::new(term1), Rc::new(term2)),
             },
-            next
+            next,
         )),
     )
 }
@@ -2756,7 +2760,7 @@ fn parse_greater_than_or_equal_to<'a, 'b>(
         GreaterThanOrEqualTo,
         next,
         error,
-        Low
+        Low,
     );
 
     // Parse the right term.
@@ -2780,7 +2784,7 @@ fn parse_greater_than_or_equal_to<'a, 'b>(
                 group: false,
                 variant: Variant::GreaterThanOrEqualTo(Rc::new(term1), Rc::new(term2)),
             },
-            next
+            next,
         )),
     )
 }
@@ -2952,13 +2956,13 @@ fn parse_group<'a, 'b>(
                 // parentheses but not both.
                 source_range: (
                     tokens[start].source_range.0,
-                    tokens[next - 1].source_range.1
+                    tokens[next - 1].source_range.1,
                 ),
                 group: true,
                 variant: term.variant,
             },
             next,
-        ))
+        )),
     )
 }
 
@@ -2988,7 +2992,7 @@ fn parse_atom<'a, 'b>(
         cache,
         Term,
         start,
-        parse_integer(cache, tokens, start, error)
+        parse_integer(cache, tokens, start, error),
     );
 
     // Try to parse an integer literal.
@@ -2996,7 +3000,7 @@ fn parse_atom<'a, 'b>(
         cache,
         Term,
         start,
-        parse_integer_literal(cache, tokens, start, error)
+        parse_integer_literal(cache, tokens, start, error),
     );
 
     // Try to parse the type of Booleans.
@@ -3004,7 +3008,7 @@ fn parse_atom<'a, 'b>(
         cache,
         Atom,
         start,
-        parse_boolean(cache, tokens, start, error)
+        parse_boolean(cache, tokens, start, error),
     );
 
     // Try to parse the logical true value.
@@ -3047,7 +3051,7 @@ fn parse_small_term<'a, 'b>(
         cache,
         SmallTerm,
         start,
-        parse_atom(cache, tokens, start, error)
+        parse_atom(cache, tokens, start, error),
     );
 
     // If we made it this far, the parse failed. If none of the parse attempts resulted in a high-
@@ -3073,7 +3077,7 @@ fn parse_medium_term<'a, 'b>(
         cache,
         MediumTerm,
         start,
-        parse_product(cache, tokens, start, error)
+        parse_product(cache, tokens, start, error),
     );
 
     // Try to parse a quotient.
@@ -3081,7 +3085,7 @@ fn parse_medium_term<'a, 'b>(
         cache,
         MediumTerm,
         start,
-        parse_quotient(cache, tokens, start, error)
+        parse_quotient(cache, tokens, start, error),
     );
 
     // Try to parse a small term.
@@ -3115,7 +3119,7 @@ fn parse_large_term<'a, 'b>(
         cache,
         LargeTerm,
         start,
-        parse_sum(cache, tokens, start, error)
+        parse_sum(cache, tokens, start, error),
     );
 
     // Try to parse a difference.
@@ -3123,7 +3127,7 @@ fn parse_large_term<'a, 'b>(
         cache,
         LargeTerm,
         start,
-        parse_difference(cache, tokens, start, error)
+        parse_difference(cache, tokens, start, error),
     );
 
     // Try to parse a medium term.
@@ -3157,7 +3161,7 @@ fn parse_huge_term<'a, 'b>(
         cache,
         HugeTerm,
         start,
-        parse_less_than(cache, tokens, start, error)
+        parse_less_than(cache, tokens, start, error),
     );
 
     // Try to parse a less than or equal to comparison.
@@ -3165,7 +3169,7 @@ fn parse_huge_term<'a, 'b>(
         cache,
         HugeTerm,
         start,
-        parse_less_than_or_equal_to(cache, tokens, start, error)
+        parse_less_than_or_equal_to(cache, tokens, start, error),
     );
 
     // Try to parse an equality comparison.
@@ -3173,7 +3177,7 @@ fn parse_huge_term<'a, 'b>(
         cache,
         HugeTerm,
         start,
-        parse_equal_to(cache, tokens, start, error)
+        parse_equal_to(cache, tokens, start, error),
     );
 
     // Try to parse a greater than comparison.
@@ -3181,7 +3185,7 @@ fn parse_huge_term<'a, 'b>(
         cache,
         HugeTerm,
         start,
-        parse_greater_than(cache, tokens, start, error)
+        parse_greater_than(cache, tokens, start, error),
     );
 
     // Try to parse a greater than or equal to comparison.
@@ -3189,7 +3193,7 @@ fn parse_huge_term<'a, 'b>(
         cache,
         HugeTerm,
         start,
-        parse_greater_than_or_equal_to(cache, tokens, start, error)
+        parse_greater_than_or_equal_to(cache, tokens, start, error),
     );
 
     // Try to parse a large term.
@@ -3239,7 +3243,7 @@ fn parse_jumbo_term<'a, 'b>(
         cache,
         JumboTerm,
         start,
-        parse_pi(cache, tokens, start, error)
+        parse_pi(cache, tokens, start, error),
     );
 
     // Try to parse an if expression.
@@ -3247,7 +3251,7 @@ fn parse_jumbo_term<'a, 'b>(
         cache,
         JumboTerm,
         start,
-        parse_if(cache, tokens, start, error)
+        parse_if(cache, tokens, start, error),
     );
 
     // Try to parse a jumbo term.
@@ -3370,7 +3374,7 @@ mod tests {
 
         assert_fails!(
             parse(None, source, &tokens[..], &context[..]),
-            "already exists"
+            "already exists",
         );
     }
 
@@ -3685,7 +3689,7 @@ mod tests {
                     Rc::new(Term {
                         source_range: Some((45, 46)),
                         variant: Variable("x", 1),
-                    })
+                    }),
                 ),
             },
         );

--- a/src/term.rs
+++ b/src/term.rs
@@ -13,7 +13,9 @@ use std::{
 // an AST.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Term<'a> {
-    pub source_range: Option<(usize, usize)>, // [start, end)
+    // Inclusive on the left and exclusive on the right
+    pub source_range: Option<(usize, usize)>,
+
     pub variant: Variant<'a>,
 }
 
@@ -118,7 +120,7 @@ impl<'a> Display for Variant<'a> {
             Self::If(condition, then_branch, else_branch) => write!(
                 f,
                 "if {} then {} else {}",
-                condition, then_branch, else_branch
+                condition, then_branch, else_branch,
             ),
         }
     }

--- a/src/token.rs
+++ b/src/token.rs
@@ -15,7 +15,9 @@ pub const TYPE_KEYWORD: &str = "type";
 // represents a single token.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Token<'a> {
-    pub source_range: (usize, usize), // [start, end)
+    // Inclusive on the left and exclusive on the right
+    pub source_range: (usize, usize),
+
     pub variant: Variant<'a>,
 }
 

--- a/src/type_checker.rs
+++ b/src/type_checker.rs
@@ -1205,7 +1205,7 @@ mod tests {
                 term_source,
                 &term_term,
                 &mut typing_context,
-                &mut definitions_context
+                &mut definitions_context,
             ),
             "has type `b` when `a` was expected",
         );

--- a/toast.yml
+++ b/toast.yml
@@ -1,11 +1,11 @@
-image: ubuntu:18.04
+image: ubuntu:19.10
 default: check
 tasks:
   install_packages:
     command: |
       set -euo pipefail
       apt-get update
-      apt-get install --yes bison build-essential curl shellcheck
+      apt-get install --yes bison build-essential curl ripgrep shellcheck
 
   install_tagref:
     dependencies:
@@ -28,7 +28,7 @@ tasks:
     command: |
       set -euo pipefail
       curl https://sh.rustup.rs -sSf |
-        sh -s -- -y --default-toolchain 1.41.0
+        sh -s -- -y --default-toolchain 1.41.1
       . $HOME/.cargo/env
       rustup component add clippy
       rustup component add rustfmt
@@ -88,18 +88,41 @@ tasks:
       - .ignore # Used by `tagref`
       - grammar.y # Checked by `bison` for shift/reduce and reduce/reduce conflicts
       - install.sh # Linted by ShellCheck
+      - release.sh # Linted by ShellCheck
     user: user
     command: |
       set -euo pipefail
       . $HOME/.cargo/env
+
+      # Lint Rust files.
       cargo clippy --all-targets --all-features -- \
         --deny warnings --deny clippy::all --deny clippy::pedantic
+
+      # Check code formatting.
       cargo fmt --all -- --check
+
+      # Check references.
       tagref
-      shellcheck install.sh
+
+      # Lint shell files.
+      shellcheck install.sh release.sh
+
+      # Check that the grammar is unambiguous.
       bison --verbose --report=itemset --report=lookahead --warnings=all -Werror grammar.y || \
         (cat grammar.output && false)
       rm grammar.output grammar.tab.c
+
+      # Enforce trailing commas in multi-line sequences.
+      if rg --multiline --type rust '[^,]\n(\s*)\)'; then
+        echo "There are multi-line sequences without trailing commas." >&2
+        exit 1
+      fi
+
+      # Forbid trailing commas in single-line sequences.
+      if rg --type rust '[^(],\s*\)'; then
+        echo "There are single-line sequences with trailing commas." >&2
+        exit 1
+      fi
 
   run:
     dependencies:


### PR DESCRIPTION
Enforce trailing commas for multi-line sequences, and forbid trailing commas for single-line sequences.

This PR also upgrades Ubuntu to 19.10 (for `ripgrep`) and Rust to 1.41.1.