### PR TITLE
Enforce the line length limit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,15 +8,7 @@ If you submit a pull request, please ensure your change passes the continuous in
 
 We are fortunate to have good tooling around enforcing a consistent style throughout the codebase. If you have [Toast](https://github.com/stepchowfun/toast), you can run the various lint checks by running `toast lint`. Otherwise, you can rely on our CI to do it for you. Here, we make note of a few conventions which are not yet enforced automatically. Please adhere to these conventions when possible, and provide appropriate justification for deviations from this guide. If you notice any style violations which appear unintentional, we invite you to bring them to our attention.
 
-### Line breaks
-
-**Rule:** Source files should be terminated by a single line break.
-
-**Rule:** There should never be two consecutive empty lines.
-
 ### Comments
-
-**Rule:** Comments should not extend past the ninety-ninth column of text.
 
 **Rule:** Comments should be written in American English.
 

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -88,7 +88,8 @@ pub fn tokenize<'a>(
                         | Variant::Minus
                         | Variant::Plus
                         | Variant::Slash
-                        | Variant::Terminator(TerminatorType::LineBreak) /* [tag:no_consecutive_line_break_terminators] */
+                        /* [tag:no_consecutive_line_break_terminators] */
+                        | Variant::Terminator(TerminatorType::LineBreak)
                         | Variant::Then
                         | Variant::ThickArrow
                         | Variant::ThinArrow => false,

--- a/toast.yml
+++ b/toast.yml
@@ -112,6 +112,12 @@ tasks:
         (cat grammar.output && false)
       rm grammar.output grammar.tab.c
 
+      # Enforce that lines span no more than 100 columns.
+      if rg --type rust '.{101}'; then
+        echo "There are lines spanning more than 100 columns." >&2
+        exit 1
+      fi
+
       # Enforce trailing commas in multi-line sequences.
       if rg --multiline --type rust '[^,]\n(\s*)\)'; then
         echo "There are multi-line sequences without trailing commas." >&2


### PR DESCRIPTION
Enforce the line length limit. Also bump it to 100 columns to match the default behavior of `cargo fmt`.