### PR TITLE
Add a missing period to an error message

### DIFF
--- a/src/type_checker.rs
+++ b/src/type_checker.rs
@@ -66,7 +66,7 @@ pub fn type_check<'a>(
                     } else {
                         Error {
                             message: format!(
-                                "Unknown type for variable {} You can fix this error by \
+                                "Unknown type for variable {}. You can fix this error by \
                                     annotating the variable where it\u{2019}s introduced.",
                                 (*variable).to_string().code_str(),
                             ),


### PR DESCRIPTION
Add a missing period to an error message.

**Status:** Ready

**Fixes:** N/A
