### PR TITLE
Remove a lint exception since the lint check has been fixed upstream

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -9,9 +9,6 @@ pub trait CodeStr {
 }
 
 impl CodeStr for str {
-    // This particular lint check is buggy and reports a nonsensical error in this function, so we
-    // disable it here.
-    #![allow(clippy::use_self)]
     fn code_str(&self) -> ColoredString {
         // If colored output is enabled, format the text in magenta. Otherwise, surround it in
         // backticks.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1528,7 +1528,6 @@ fn parse_false<'a>(
 }
 
 // Parse an if expression.
-#[allow(clippy::too_many_lines)]
 fn parse_if<'a>(cache: &mut Cache<'a>, tokens: &'a [Token<'a>], start: usize) -> (Term<'a>, usize) {
     // Check the cache.
     let cache_key = cache_check!(cache, If, start);


### PR DESCRIPTION
Remove a lint exception since the lint check has been fixed upstream.

I also manually verified that all but one of the remaining lint exceptions are still necessary. The unnecessary one is also removed by this PR.

So after this PR all the lint exceptions are necessary.

**Status:** Ready

**Fixes:** N/A
