### PR TITLE
When rendering errors when the output isn't colorized, highlight the relevant sections of the code listing with ASCII art

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -134,7 +134,27 @@ fn run(source_path: &Path, check_only: bool) -> Result<(), Error> {
         parse(Some(source_path), &source_contents, &tokens[..], &[]).map_err(|errors| Error {
             message: errors
                 .iter()
-                .fold(String::new(), |acc, error| format!("{}\n\n{}", acc, error))
+                .fold(String::new(), |acc, error| {
+                    format!(
+                        "{}\n{}{}",
+                        acc,
+                        // Only render an empty line between errors here if the previous line
+                        // doesn't already visually look like an empty line. See
+                        // [ref:overline_u203e].
+                        if acc
+                            .split('\n')
+                            .last()
+                            .unwrap()
+                            .chars()
+                            .all(|c| c == ' ' || c == '\u{203e}')
+                        {
+                            ""
+                        } else {
+                            "\n"
+                        },
+                        error,
+                    )
+                })
                 .trim()
                 .to_owned(),
             reason: None,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -126,7 +126,9 @@ fn span(x: SourceRange, y: SourceRange) -> SourceRange {
 fn token_source_range<'a>(tokens: &'a [Token<'a>], position: usize) -> SourceRange {
     if position == tokens.len() {
         SourceRange {
-            0: tokens.last().map_or((0, 0), |token| token.source_range),
+            0: tokens
+                .last()
+                .map_or((0, 0), |token| (token.source_range.1, token.source_range.1)),
         }
     } else {
         SourceRange {


### PR DESCRIPTION
When rendering errors when the output isn't colorized, highlight the relevant sections of the code listing with ASCII art. Screenshots speak a thousand words:

<img width="525" alt="Screenshot 2020-03-29 18 08 32" src="https://user-images.githubusercontent.com/796574/77866533-5fb0e000-71e8-11ea-974a-85af89daa558.png">

<img width="1277" alt="Screenshot 2020-03-29 18 08 54" src="https://user-images.githubusercontent.com/796574/77866535-617aa380-71e8-11ea-91a5-c603a5a035d7.png">

**Status:** Ready

**Fixes:** N/A
