### PR TITLE
Syntactically allow lambdas without annotations on the parameters

### DIFF
--- a/grammar.y
+++ b/grammar.y
@@ -54,7 +54,8 @@
 term: let | jumbo_term;
 type: TYPE;
 variable: IDENTIFIER;
-lambda: LEFT_PAREN IDENTIFIER COLON jumbo_term RIGHT_PAREN THICK_ARROW term;
+lambda: IDENTIFIER THICK_ARROW term;
+annotated_lambda: LEFT_PAREN IDENTIFIER COLON jumbo_term RIGHT_PAREN THICK_ARROW term;
 pi: LEFT_PAREN IDENTIFIER COLON jumbo_term RIGHT_PAREN THIN_ARROW term;
 non_dependent_pi: small_term THIN_ARROW term;
 application: atom small_term;
@@ -89,4 +90,4 @@ giant_term:
   greater_than |
   greater_than_or_equal_to |
   huge_term;
-jumbo_term: lambda | pi | non_dependent_pi | if | giant_term;
+jumbo_term: lambda | annotated_lambda | pi | non_dependent_pi | if | giant_term;

--- a/src/de_bruijn.rs
+++ b/src/de_bruijn.rs
@@ -29,7 +29,9 @@ pub fn shift<'a>(term: Rc<Term<'a>>, cutoff: usize, amount: usize) -> Rc<Term<'a
             source_range: term.source_range,
             variant: Lambda(
                 variable,
-                shift(domain.clone(), cutoff, amount),
+                domain
+                    .as_ref()
+                    .map(|domain| shift(domain.clone(), cutoff, amount)),
                 shift(body.clone(), cutoff + 1, amount),
             ),
         }),
@@ -176,12 +178,14 @@ pub fn open<'a>(
             source_range: term_to_open.source_range,
             variant: Lambda(
                 variable,
-                open(
-                    domain.clone(),
-                    index_to_replace,
-                    term_to_insert.clone(),
-                    shift_amount,
-                ),
+                domain.as_ref().map(|domain| {
+                    open(
+                        domain.clone(),
+                        index_to_replace,
+                        term_to_insert.clone(),
+                        shift_amount,
+                    )
+                }),
                 open(
                     body.clone(),
                     index_to_replace + 1,
@@ -464,7 +468,10 @@ pub fn free_variables<'a>(term: &Term<'a>, cutoff: usize, variables: &mut HashSe
             }
         }
         Lambda(_, domain, body) => {
-            free_variables(domain, cutoff, variables);
+            if let Some(domain) = domain {
+                free_variables(domain, cutoff, variables);
+            }
+
             free_variables(body, cutoff + 1, variables);
         }
         Pi(_, domain, codomain) => {
@@ -586,10 +593,10 @@ mod tests {
                     source_range: Some((97, 112)),
                     variant: Lambda(
                         "a",
-                        Rc::new(Term {
+                        Some(Rc::new(Term {
                             source_range: Some((102, 106)),
                             variant: Variable("b", 0),
-                        }),
+                        })),
                         Rc::new(Term {
                             source_range: Some((111, 112)),
                             variant: Variable("b", 1),
@@ -603,10 +610,10 @@ mod tests {
                 source_range: Some((97, 112)),
                 variant: Lambda(
                     "a",
-                    Rc::new(Term {
+                    Some(Rc::new(Term {
                         source_range: Some((102, 106)),
                         variant: Variable("b", 42),
-                    }),
+                    })),
                     Rc::new(Term {
                         source_range: Some((111, 112)),
                         variant: Variable("b", 43),
@@ -1344,10 +1351,10 @@ mod tests {
                     source_range: Some((97, 112)),
                     variant: Lambda(
                         "a",
-                        Rc::new(Term {
+                        Some(Rc::new(Term {
                             source_range: Some((102, 106)),
                             variant: Variable("b", 0),
-                        }),
+                        })),
                         Rc::new(Term {
                             source_range: Some((111, 112)),
                             variant: Variable("b", 1),
@@ -1365,10 +1372,10 @@ mod tests {
                 source_range: Some((97, 112)),
                 variant: Lambda(
                     "a",
-                    Rc::new(Term {
+                    Some(Rc::new(Term {
                         source_range: Some((3, 4)),
                         variant: Variable("x", 4),
-                    }),
+                    })),
                     Rc::new(Term {
                         source_range: Some((3, 4)),
                         variant: Variable("x", 5),
@@ -2143,10 +2150,10 @@ mod tests {
                 source_range: Some((97, 112)),
                 variant: Lambda(
                     "a",
-                    Rc::new(Term {
+                    Some(Rc::new(Term {
                         source_range: Some((102, 106)),
                         variant: Variable("b", 15),
-                    }),
+                    })),
                     Rc::new(Term {
                         source_range: Some((111, 112)),
                         variant: Variable("b", 15),

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -689,7 +689,7 @@ mod tests {
                 source_range: Some((0, 39)),
                 variant: Lambda(
                     "f",
-                    Rc::new(Term {
+                    Some(Rc::new(Term {
                         source_range: Some((5, 17)),
                         variant: Pi(
                             "_",
@@ -702,15 +702,15 @@ mod tests {
                                 variant: Type,
                             }),
                         ),
-                    }),
+                    })),
                     Rc::new(Term {
                         source_range: Some((22, 39)),
                         variant: Lambda(
                             "x",
-                            Rc::new(Term {
+                            Some(Rc::new(Term {
                                 source_range: Some((27, 31)),
                                 variant: Type,
-                            }),
+                            })),
                             Rc::new(Term {
                                 source_range: Some((36, 39)),
                                 variant: Application(

--- a/src/normalizer.rs
+++ b/src/normalizer.rs
@@ -485,17 +485,17 @@ mod tests {
                 source_range: Some((0, 48)),
                 variant: Lambda(
                     "x",
-                    Rc::new(Term {
+                    Some(Rc::new(Term {
                         source_range: Some((5, 24)),
                         variant: Application(
                             Rc::new(Term {
                                 source_range: Some((5, 22)),
                                 variant: Lambda(
                                     "y",
-                                    Rc::new(Term {
+                                    Some(Rc::new(Term {
                                         source_range: Some((11, 15)),
                                         variant: Type,
-                                    }),
+                                    })),
                                     Rc::new(Term {
                                         source_range: Some((20, 21)),
                                         variant: Variable("y", 0),
@@ -507,7 +507,7 @@ mod tests {
                                 variant: Variable("p", 1),
                             }),
                         ),
-                    }),
+                    })),
                     Rc::new(Term {
                         source_range: Some((29, 48)),
                         variant: Application(
@@ -515,10 +515,10 @@ mod tests {
                                 source_range: Some((29, 46)),
                                 variant: Lambda(
                                     "z",
-                                    Rc::new(Term {
+                                    Some(Rc::new(Term {
                                         source_range: Some((35, 39)),
                                         variant: Type,
-                                    }),
+                                    })),
                                     Rc::new(Term {
                                         source_range: Some((44, 45)),
                                         variant: Variable("z", 0),
@@ -558,10 +558,10 @@ mod tests {
                                 source_range: Some((5, 22)),
                                 variant: Lambda(
                                     "y",
-                                    Rc::new(Term {
+                                    Some(Rc::new(Term {
                                         source_range: Some((11, 15)),
                                         variant: Type,
-                                    }),
+                                    })),
                                     Rc::new(Term {
                                         source_range: Some((20, 21)),
                                         variant: Variable("y", 0),
@@ -581,10 +581,10 @@ mod tests {
                                 source_range: Some((29, 46)),
                                 variant: Lambda(
                                     "z",
-                                    Rc::new(Term {
+                                    Some(Rc::new(Term {
                                         source_range: Some((35, 39)),
                                         variant: Type,
-                                    }),
+                                    })),
                                     Rc::new(Term {
                                         source_range: Some((44, 45)),
                                         variant: Variable("z", 0),
@@ -627,10 +627,10 @@ mod tests {
                                 source_range: Some((23, 40)),
                                 variant: Lambda(
                                     "z",
-                                    Rc::new(Term {
+                                    Some(Rc::new(Term {
                                         source_range: Some((29, 33)),
                                         variant: Type,
-                                    }),
+                                    })),
                                     Rc::new(Term {
                                         source_range: Some((38, 39)),
                                         variant: Variable("z", 0),

--- a/src/term.rs
+++ b/src/term.rs
@@ -22,7 +22,7 @@ pub struct Term<'a> {
 pub enum Variant<'a> {
     Type,
     Variable(&'a str, usize),
-    Lambda(&'a str, Rc<Term<'a>>, Rc<Term<'a>>),
+    Lambda(&'a str, Option<Rc<Term<'a>>>, Rc<Term<'a>>),
     Pi(&'a str, Rc<Term<'a>>, Rc<Term<'a>>),
     Application(Rc<Term<'a>>, Rc<Term<'a>>),
     #[allow(clippy::type_complexity)]
@@ -61,7 +61,11 @@ impl<'a> Display for Variant<'a> {
             Self::Type => write!(f, "{}", TYPE_KEYWORD),
             Self::Variable(variable, _) => write!(f, "{}", variable),
             Self::Lambda(variable, domain, body) => {
-                write!(f, "({} : {}) => {}", variable, domain, body)
+                if let Some(domain) = domain {
+                    write!(f, "({} : {}) => {}", variable, domain, body)
+                } else {
+                    write!(f, "{} => {}", variable, body)
+                }
             }
             Self::Pi(variable, domain, codomain) => {
                 let mut variables = HashSet::new();

--- a/src/type_checker.rs
+++ b/src/type_checker.rs
@@ -69,11 +69,21 @@ pub fn type_check<'a>(
             }
         }
         Lambda(variable, domain, body) => {
+            // Check that we have a domain.
+            let domain = domain.as_ref().ok_or_else(|| {
+                throw(
+                    "The argument to this function needs a type annotation:",
+                    source_path,
+                    term.source_range
+                        .map(|source_range| (source_contents, source_range)),
+                )
+            })?;
+
             // Infer the type of the domain.
             let domain_type = type_check(
                 source_path,
                 source_contents,
-                &**domain,
+                domain,
                 typing_context,
                 definitions_context,
             )?;


### PR DESCRIPTION
Syntactically allow lambdas without annotations on the parameters. This is in preparation for type inference. For now, lambdas without annotations will parse but will result in a type error.

**Status:** Ready

**Fixes:** N/A
