### PR TITLE
Make errors easier to spot with colors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -53,22 +53,24 @@ pub fn throw(
             message: if let Some(path) = source_path {
                 if listing.is_empty() {
                     format!(
-                        "Error in {}: {}",
-                        path.to_string_lossy().code_str(),
+                        "{} {} {}",
+                        "[Error]".red().bold(),
+                        format!("[{}]", path.to_string_lossy().code_str()).magenta(),
                         message,
                     )
                 } else {
                     format!(
-                        "Error in {}: {}\n\n{}",
-                        path.to_string_lossy().code_str(),
+                        "{} {} {}\n\n{}",
+                        "[Error]".red().bold(),
+                        format!("[{}]", path.to_string_lossy().code_str()).magenta(),
                         message,
                         listing,
                     )
                 }
             } else if listing.is_empty() {
-                format!("Error: {}", message)
+                format!("{} {}", "[Error]".red().bold(), message)
             } else {
-                format!("Error: {}\n\n{}", message, listing)
+                format!("{} {}\n\n{}", "[Error]".red().bold(), message, listing)
             },
             reason: None,
         }
@@ -259,7 +261,7 @@ mod tests {
 
         let error = throw("An error occurred.", None, None);
 
-        assert_eq!(error.message, "Error: An error occurred.");
+        assert_eq!(error.message, "[Error] An error occurred.");
     }
 
     #[test]
@@ -268,7 +270,7 @@ mod tests {
 
         let error = throw("An error occurred.", None, Some(("", (0, 0))));
 
-        assert_eq!(error.message, "Error: An error occurred.");
+        assert_eq!(error.message, "[Error] An error occurred.");
     }
 
     #[test]
@@ -277,7 +279,7 @@ mod tests {
 
         let error = throw("An error occurred.", Some(Path::new("foo.g")), None);
 
-        assert_eq!(error.message, "Error in `foo.g`: An error occurred.");
+        assert_eq!(error.message, "[Error] [`foo.g`] An error occurred.");
     }
 
     #[test]
@@ -290,7 +292,7 @@ mod tests {
             Some(("", (0, 0))),
         );
 
-        assert_eq!(error.message, "Error in `foo.g`: An error occurred.");
+        assert_eq!(error.message, "[Error] [`foo.g`] An error occurred.");
     }
 
     #[test]
@@ -301,7 +303,7 @@ mod tests {
 
         assert_eq!(
             error.message,
-            "Error: An error occurred.\n\n1 \u{2502} foo\n    \u{203e}\u{203e}\u{203e}",
+            "[Error] An error occurred.\n\n1 \u{2502} foo\n    \u{203e}\u{203e}\u{203e}",
         );
     }
 
@@ -317,7 +319,7 @@ mod tests {
 
         assert_eq!(
             error.message,
-            "Error in `foo.g`: An error occurred.\n\n1 \u{2502} foo\n    \u{203e}\u{203e}\u{203e}",
+            "[Error] [`foo.g`] An error occurred.\n\n1 \u{2502} foo\n    \u{203e}\u{203e}\u{203e}",
         );
     }
 
@@ -329,7 +331,7 @@ mod tests {
 
         assert_eq!(
             error.message,
-            "Error: An error occurred.\n\n1 \u{2502} foo\n  \u{250a} \u{203e}\u{203e}\u{203e}\n2 \
+            "[Error] An error occurred.\n\n1 \u{2502} foo\n  \u{250a} \u{203e}\u{203e}\u{203e}\n2 \
                 \u{2502} bar\n  \u{250a} \u{203e}\u{203e}\u{203e}\n3 \u{2502} baz\n    \u{203e}\
                 \u{203e}\u{203e}",
         );
@@ -347,8 +349,8 @@ mod tests {
 
         assert_eq!(
             error.message,
-            "Error: An error occurred.\n\n2 \u{2502} bar\n  \u{250a}  \u{203e}\u{203e}\n3 \u{2502} \
-                baz\n    \u{203e}\u{203e}\u{203e}",
+            "[Error] An error occurred.\n\n2 \u{2502} bar\n  \u{250a}  \u{203e}\u{203e}\n3 \
+                \u{2502} baz\n    \u{203e}\u{203e}\u{203e}",
         );
     }
 
@@ -367,7 +369,7 @@ mod tests {
 
         assert_eq!(
             error.message,
-            "Error: An error occurred.\n\n 9 \u{2502} foo\n   \u{250a}  \u{203e}\u{203e}\n10 \
+            "[Error] An error occurred.\n\n 9 \u{2502} foo\n   \u{250a}  \u{203e}\u{203e}\n10 \
                 \u{2502} bar\n   \u{250a} \u{203e}\u{203e}\u{203e}\n11 \u{2502} baz\n     \u{203e}\
                 \u{203e}",
         );

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -6,6 +6,7 @@ use crate::{
     term,
     token::{self, TerminatorType, Token},
 };
+use colored::Colorize;
 use num_bigint::BigInt;
 use scopeguard::defer;
 use std::{
@@ -1770,6 +1771,7 @@ fn parse_if<'a>(
 }
 
 // Parse a group.
+#[allow(clippy::too_many_lines)]
 fn parse_group<'a>(
     cache: &mut Cache<'a>,
     tokens: &'a [Token<'a>],
@@ -1844,32 +1846,37 @@ fn parse_group<'a>(
                     {
                         if let Some(path) = source_path {
                             format!(
-                                "Error in {}: This parenthesis was never closed:\n\n{}\n\nIt was \
+                                "{} {} This parenthesis was never closed:\n\n{}\n\nIt was \
                                     expected to be closed at the end of this line:\n\n{}",
-                                path.to_string_lossy().code_str(),
+                                "[Error]".red().bold(),
+                                format!("[{}]", path.to_string_lossy().code_str()).magenta(),
                                 left_parenthesis_listing,
                                 unexpected_token_listing,
                             )
                         } else {
                             format!(
-                                "Error: This parenthesis was never closed:\n\n{}\n\nIt was \
+                                "{} This parenthesis was never closed:\n\n{}\n\nIt was \
                                     expected to be closed at the end of this line:\n\n{}",
-                                left_parenthesis_listing, unexpected_token_listing,
+                                "[Error]".red().bold(),
+                                left_parenthesis_listing,
+                                unexpected_token_listing,
                             )
                         }
                     } else if let Some(path) = source_path {
                         format!(
-                            "Error in {}: This parenthesis was never closed:\n\n{}\n\nIt was \
+                            "{} {} This parenthesis was never closed:\n\n{}\n\nIt was \
                                 expected to be closed before {}:\n\n{}",
-                            path.to_string_lossy().code_str(),
+                            "[Error]".red().bold(),
+                            format!("[{}]", path.to_string_lossy().code_str()).magenta(),
                             left_parenthesis_listing,
                             tokens[next].to_string().code_str(),
                             unexpected_token_listing,
                         )
                     } else {
                         format!(
-                            "Error: This parenthesis was never closed:\n\n{}\n\nIt was \
+                            "{} This parenthesis was never closed:\n\n{}\n\nIt was \
                                 expected to be closed before {}:\n\n{}",
+                            "[Error]".red().bold(),
                             left_parenthesis_listing,
                             tokens[next].to_string().code_str(),
                             unexpected_token_listing,


### PR DESCRIPTION
Make errors easier to spot with colors.

Before:

<img width="432" alt="Screenshot 2020-04-01 20 03 58" src="https://user-images.githubusercontent.com/796574/78206591-1fee3080-7454-11ea-8a31-65d860fc990f.png">
<img width="483" alt="Screenshot 2020-04-01 20 04 16" src="https://user-images.githubusercontent.com/796574/78206593-2086c700-7454-11ea-9c78-c9a981fd3f08.png">

After:

<img width="431" alt="Screenshot 2020-04-01 20 04 44" src="https://user-images.githubusercontent.com/796574/78206594-211f5d80-7454-11ea-84f7-864a404be64b.png">
<img width="480" alt="Screenshot 2020-04-01 20 04 54" src="https://user-images.githubusercontent.com/796574/78206596-21b7f400-7454-11ea-9da4-fdfe13954a66.png">


**Status:** Ready

**Fixes:** N/A
