### PR TITLE
When printing unifiers, don't surround them with curly braces

### DIFF
--- a/src/term.rs
+++ b/src/term.rs
@@ -59,7 +59,7 @@ impl<'a> Display for Variant<'a> {
         match self {
             Self::Unifier(subterm) => {
                 if let Some(subterm) = &*subterm.borrow() {
-                    write!(f, "{{{}}}", subterm)
+                    write!(f, "{}", subterm)
                 } else {
                     write!(f, "?")
                 }
@@ -130,9 +130,15 @@ impl<'a> Display for Variant<'a> {
 // Convert a term to a string with surrounding parentheses, except for simple terms that cause no
 // parsing ambiguities in any context.
 fn group<'a>(term: &Term<'a>) -> String {
-    match term.variant {
-        Variant::Unifier(_)
-        | Variant::Type
+    match &term.variant {
+        Variant::Unifier(subterm) => {
+            if let Some(subterm) = &*subterm.borrow() {
+                group(&subterm)
+            } else {
+                format!("{}", term)
+            }
+        }
+        Variant::Type
         | Variant::Variable(_, _)
         | Variant::Integer
         | Variant::IntegerLiteral(_)

--- a/src/type_checker.rs
+++ b/src/type_checker.rs
@@ -833,7 +833,7 @@ mod tests {
                 &mut typing_context,
                 &mut definitions_context,
             ),
-            "has type `b`, but it should have type `{a}`",
+            "has type `b`, but it should have type `a`",
         );
     }
 


### PR DESCRIPTION
When printing unifiers, don't surround them with curly braces.

**Status:** Ready

**Fixes:** N/A
