### PR TITLE
Refactor the type checker to support reporting multiple type errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -213,32 +213,6 @@ macro_rules! assert_fails {
         colored::control::set_override(false);
 
         // Check that `$expr` fails and that the failure contains `$substr`.
-        if let Err(error) = expr {
-            let error_string = error.to_string();
-
-            assert!(error_string.contains(substr), error_string);
-        } else {
-            assert!(
-                false,
-                "The expression was supposed to fail, but it succeeded.",
-            );
-        }
-    }};
-}
-
-// This macro is useful for writing tests that deal with errors.
-#[macro_export]
-macro_rules! assert_fails_vec {
-    ($expr:expr, $substr:expr $(,)?) => {{
-        // Macros are call-by-name, but we want call-by-value (or at least call-by-need) to avoid
-        // accidentally evaluating arguments multiple times. Here we force eager evaluation.
-        let expr = $expr;
-        let substr = $substr;
-
-        // Before we actually evaluate the expression, disable terminal colors.
-        colored::control::set_override(false);
-
-        // Check that `$expr` fails and that the failure contains `$substr`.
         if let Err(errors) = expr {
             let mut found_error = false;
             let mut all_errors_string = "".to_owned();

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,46 +120,42 @@ fn run(source_path: &Path, check_only: bool) -> Result<(), Error> {
         source_path.to_string_lossy().code_str(),
     )))?;
 
-    // Tokenize the source file.
-    let tokens = tokenize(Some(source_path), &source_contents).map_err(|errors| Error {
+    // Here is a helper function for mapping a `Vec<Error>` to a single `Error`.
+    let collect_errors = |errors: Vec<Error>| Error {
         message: errors
             .iter()
-            .fold(String::new(), |acc, error| format!("{}\n\n{}", acc, error))
+            .fold(String::new(), |acc, error| {
+                format!(
+                    "{}\n{}{}",
+                    acc,
+                    // Only render an empty line between errors here if the previous line
+                    // doesn't already visually look like an empty line. See
+                    // [ref:overline_u203e].
+                    if acc
+                        .split('\n')
+                        .last()
+                        .unwrap()
+                        .chars()
+                        .all(|c| c == ' ' || c == '\u{203e}')
+                    {
+                        ""
+                    } else {
+                        "\n"
+                    },
+                    error,
+                )
+            })
             .trim()
             .to_owned(),
         reason: None,
-    })?;
+    };
+
+    // Tokenize the source file.
+    let tokens = tokenize(Some(source_path), &source_contents).map_err(collect_errors)?;
 
     // Parse the term.
     let term =
-        parse(Some(source_path), &source_contents, &tokens[..], &[]).map_err(|errors| Error {
-            message: errors
-                .iter()
-                .fold(String::new(), |acc, error| {
-                    format!(
-                        "{}\n{}{}",
-                        acc,
-                        // Only render an empty line between errors here if the previous line
-                        // doesn't already visually look like an empty line. See
-                        // [ref:overline_u203e].
-                        if acc
-                            .split('\n')
-                            .last()
-                            .unwrap()
-                            .chars()
-                            .all(|c| c == ' ' || c == '\u{203e}')
-                        {
-                            ""
-                        } else {
-                            "\n"
-                        },
-                        error,
-                    )
-                })
-                .trim()
-                .to_owned(),
-            reason: None,
-        })?;
+        parse(Some(source_path), &source_contents, &tokens[..], &[]).map_err(collect_errors)?;
 
     // Type check the term.
     let mut typing_context = vec![];
@@ -170,7 +166,8 @@ fn run(source_path: &Path, check_only: bool) -> Result<(), Error> {
         &term,
         &mut typing_context,
         &mut definitions_context,
-    )?;
+    )
+    .map_err(collect_errors)?;
 
     // Evaluate the term.
     if !check_only {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3856,7 +3856,7 @@ fn check_definition<'a>(
 #[cfg(test)]
 mod tests {
     use crate::{
-        assert_fails_vec,
+        assert_fails,
         parser::parse,
         term::{
             Term,
@@ -3878,7 +3878,7 @@ mod tests {
         let tokens = tokenize(None, source).unwrap();
         let context = [];
 
-        assert_fails_vec!(
+        assert_fails!(
             parse(None, source, &tokens[..], &context[..]),
             "file is empty",
         );
@@ -3935,7 +3935,7 @@ mod tests {
         let tokens = tokenize(None, source).unwrap();
         let context = [];
 
-        assert_fails_vec!(
+        assert_fails!(
             parse(None, source, &tokens[..], &context[..]),
             "not in scope",
         );
@@ -3997,7 +3997,7 @@ mod tests {
         let tokens = tokenize(None, source).unwrap();
         let context = ["a", "x"];
 
-        assert_fails_vec!(
+        assert_fails!(
             parse(None, source, &tokens[..], &context[..]),
             "already exists",
         );
@@ -4069,7 +4069,7 @@ mod tests {
         let tokens = tokenize(None, source).unwrap();
         let context = ["a", "x"];
 
-        assert_fails_vec!(
+        assert_fails!(
             parse(None, source, &tokens[..], &context[..]),
             "already exists",
         );

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -363,7 +363,7 @@ pub fn tokenize<'a>(
 #[cfg(test)]
 mod tests {
     use crate::{
-        assert_fails_vec,
+        assert_fails,
         token::{
             TerminatorType, Token, Variant, BOOLEAN_KEYWORD, ELSE_KEYWORD, FALSE_KEYWORD,
             IF_KEYWORD, INTEGER_KEYWORD, THEN_KEYWORD, TRUE_KEYWORD, TYPE_KEYWORD,
@@ -784,6 +784,6 @@ mod tests {
 
     #[test]
     fn tokenize_unexpected_code_point() {
-        assert_fails_vec!(tokenize(None, "$"), "Unexpected symbol");
+        assert_fails!(tokenize(None, "$"), "Unexpected symbol");
     }
 }


### PR DESCRIPTION
Refactor the type checker to support reporting multiple type errors. Amazingly, this change reduced the total number of lines of code.

**Status:** Ready

**Fixes:** N/A
