### PR TITLE
Add a type annotation to ensure the correct pointer is being hashed

### DIFF
--- a/src/unifier.rs
+++ b/src/unifier.rs
@@ -25,7 +25,8 @@ struct HashableRc<T>(Rc<T>);
 
 impl<T> Hash for HashableRc<T> {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        ptr::hash(&*self.0, state);
+        let reference: &T = &*self.0;
+        ptr::hash(reference, state);
     }
 }
 


### PR DESCRIPTION
Add a type annotation to ensure the correct pointer is being hashed. We want to make sure we are hashing `&T` values, and not accidentally hashing `&&T` values or `&Rc<T>` hashing.

**Status:** Ready

**Fixes:** N/A
