### PR TITLE
Adopt a universal convention for term processing: pass-by-reference and return-by-value

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ use clap::{
     AppSettings::{ArgRequiredElseHelp, ColoredHelp, UnifiedHelpMessage, VersionlessSubcommands},
     Arg, Shell, SubCommand,
 };
-use std::{fs::read_to_string, io::stdout, path::Path, process::exit, rc::Rc, thread};
+use std::{fs::read_to_string, io::stdout, path::Path, process::exit, thread};
 
 // The program version
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -171,7 +171,7 @@ fn run(source_path: &Path, check_only: bool) -> Result<(), Error> {
 
     // Evaluate the term.
     if !check_only {
-        let value = evaluate(Rc::new(term))?;
+        let value = evaluate(&term)?;
         println!("{}", value.to_string().code_str());
     }
 


### PR DESCRIPTION
Adopt a universal convention for `Term` processing: pass-by-reference and return-by-value.

Before this change, such functions were inconsistently accepting references or `Rc`s, and generally returning `Rc`s. The choice of whether to accept a reference or an `Rc` was made with consideration for performance: a function which might return its input unmodified should take an `Rc` to avoid unnecessary allocation and copying.

However, I benchmarked this change and found no noticeable performance hit. It simplifies the code, as demonstrated by the fact that this PR removes 283 lines of code in total. I suspect the compiler (for Rust, not Gram) might be doing some copy elision.

For the record, I also benchmarked a change that replaced all the `Rc`s by `Box`es. However, this resulted in a significant performance hit because terms were being deep-copied in some situations.

**Status:** Ready

**Fixes:** N/A
