### PR TITLE
Fix a bug in the evaluation of `let`s

### DIFF
--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -101,7 +101,7 @@ pub fn step<'a>(term: &Term<'a>) -> Option<Term<'a>> {
                         source_range: None,
                         variant: Let(
                             once((*variable, annotation.clone(), Rc::new(stepped_definition)))
-                                .chain(definitions.iter().map(
+                                .chain(definitions.iter().skip(1).map(
                                     |(variable, annotation, definition)| {
                                         (*variable, annotation.clone(), definition.clone())
                                     },

--- a/src/unifier.rs
+++ b/src/unifier.rs
@@ -1040,7 +1040,7 @@ mod tests {
     fn collect_unifiers_unresolved() {
         let parsing_context = [];
 
-        let source = "x => x + 3";
+        let source = "(x => x) type";
         let tokens = tokenize(None, source).unwrap();
         let term = parse(None, source, &tokens[..], &parsing_context[..]).unwrap();
 
@@ -1057,7 +1057,7 @@ mod tests {
         let mut typing_context = vec![];
         let mut definitions_context = vec![];
 
-        let source = "x => x + 3";
+        let source = "(x => x) type";
         let tokens = tokenize(None, source).unwrap();
         let term = parse(None, source, &tokens[..], &parsing_context[..]).unwrap();
         let _ = type_check(


### PR DESCRIPTION
Fix a bug in the evaluation of `let`s. I also changed a couple of tests to not depend on arithmetic.

**Status:** Ready

**Fixes:** N/A
