### PR TITLE
Fix a bug in the type checking logic for pi types

### DIFF
--- a/src/type_checker.rs
+++ b/src/type_checker.rs
@@ -164,10 +164,6 @@ pub fn type_check_rec<'a>(
                 errors,
             );
 
-            // Restore the context.
-            definitions_context.pop();
-            typing_context.pop();
-
             // Check that the type of the codomain is the type of all types.
             if !unify(&codomain_type, &type_term, definitions_context) {
                 errors.push(throw(
@@ -178,6 +174,10 @@ pub fn type_check_rec<'a>(
                         .map(|source_range| (source_contents, source_range)),
                 ));
             }
+
+            // Restore the context.
+            definitions_context.pop();
+            typing_context.pop();
 
             // The type of a pi type is the type of all types.
             type_term


### PR DESCRIPTION
Fix a bug in the type checking logic for pi types.

This program should be a type error:

```gram
(a : type) -> (x : a) -> x
```

But before this PR, it leads to a panic during type checking:

```sh
$ gram main.g
thread '<unnamed>' panicked at 'index out of bounds: the len is 1 but the index is 18446744073709551615', /rustc/b8cedc00407a4c56a3bda1ed605c6fc166655447/src/libcore/slice/mod.rs:2791:10
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Error joining thread: Any
```

Now, Gram reports the expected type error:

```gram
[Error] [`main.g`] This is not a type:

1 │ (a : type) -> (x : a) -> x
                             ‾
```

**Status:** Ready

**Fixes:** N/A
