### PR TITLE
Fix a bug in the install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -59,8 +59,8 @@
 
   # Install it at the requested destination.
   # shellcheck disable=SC2024
-  mv "$FILENAME" "$DESTINATION" 2> /dev/null ||
-    sudo mv "$FILENAME" "$DESTINATION" < /dev/tty ||
+  mv -f "$FILENAME" "$DESTINATION" 2> /dev/null ||
+    sudo mv -f "$FILENAME" "$DESTINATION" < /dev/tty ||
     fail "Unable to install the binary at $DESTINATION."
 
   # Remove the temporary directory.


### PR DESCRIPTION
Fix a bug in the install script.

The bug is due to:

- `mv` may ask for confirmation before overwriting an existing file.
- When asking for confirmation, it defaults to "abort" if the user just presses `<ENTER>`.
- When the user chooses the abort option, `mv` returns 0 and the script doesn't report the failure.

**Status:** Ready

**Fixes:** N/A