### PR TITLE
Remove extra trailing commas that were previously needed to satisfy the trailing comma lint check

### DIFF
--- a/src/assertions.rs
+++ b/src/assertions.rs
@@ -98,7 +98,7 @@ mod tests {
                 Error { message: \"foo\", reason: None }, \
                 Error { message: \"bar\", reason: None }, \
                 Error { message: \"baz\", reason: None }\
-            ]." // ,
+            ]."
     )]
     fn assert_fails_mismatch() {
         let success: Result<usize, Vec<Error>> = Err(vec![

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -328,7 +328,7 @@ macro_rules! consume_token_0 {
         $tokens:expr,
         $next:expr,
         $variant:ident,
-        $expectation:expr $(,)? // This comma is needed to satisfy the trailing commas check: ,
+        $expectation:expr $(,)?
     ) => {{
         // Macros are call-by-name, but we want call-by-value (or at least call-by-need) to avoid
         // accidentally evaluating arguments multiple times. Here we force eager evaluation.
@@ -368,7 +368,7 @@ macro_rules! consume_token_1 {
         $tokens:expr,
         $next:expr,
         $variant:ident,
-        $expectation:expr $(,)? // This comma is needed to satisfy the trailing commas check: ,
+        $expectation:expr $(,)?
     ) => {{
         // Macros are call-by-name, but we want call-by-value (or at least call-by-need) to avoid
         // accidentally evaluating arguments multiple times. Here we force eager evaluation.
@@ -411,7 +411,7 @@ macro_rules! expect_token_0 {
         $errors:ident,
         $variant:ident,
         $expectation:expr,
-        $report_error:expr $(,)? // This comma is needed to satisfy the trailing commas check: ,
+        $report_error:expr $(,)?
     ) => {{
         // Macros are call-by-name, but we want call-by-value (or at least call-by-need) to avoid
         // accidentally evaluating arguments multiple times. Here we force eager evaluation.
@@ -476,7 +476,7 @@ macro_rules! expect_token_1 {
         $errors:ident,
         $variant:ident,
         $expectation:expr,
-        $report_error:expr $(,)? // This comma is needed to satisfy the trailing commas check: ,
+        $report_error:expr $(,)?
     ) => {{
         // Macros are call-by-name, but we want call-by-value (or at least call-by-need) to avoid
         // accidentally evaluating arguments multiple times. Here we force eager evaluation.

--- a/src/type_checker.rs
+++ b/src/type_checker.rs
@@ -1376,13 +1376,13 @@ mod tests {
         let mut definitions_context = vec![None, None];
         let term_source = "
           (
-            (a : type) => (P: a -> type) => (f : (x : a) -> P x) => (x : a) => f x # ,
+            (a : type) => (P: a -> type) => (f : (x : a) -> P x) => (x : a) => f x
           ) (
-            ((t : type) => t) foo # ,
+            ((t : type) => t) foo
           ) (
-            (x : foo) => foo # ,
+            (x : foo) => foo
           ) (
-            (x : foo) => x # ,
+            (x : foo) => x
           ) y
         ";
         let type_source = "foo";


### PR DESCRIPTION
Remove extra trailing commas that were previously needed to satisfy the trailing comma lint check.

**Status:** Ready

**Fixes:** N/A
