### PR TITLE
Update the way lints are configured to use Rust's new `manifest-lint` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,11 @@ homepage = "https://github.com/gramlang/gram"
 repository = "https://github.com/gramlang/gram"
 readme = "README.md"
 
+[lints]
+clippy.all = "deny"
+clippy.pedantic = "deny"
+rust.warnings = "deny"
+
 [dependencies]
 colored = "1"
 num-bigint = "0.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-#![deny(clippy::all, clippy::pedantic, warnings)]
-
 mod assertions;
 mod de_bruijn;
 mod equality;


### PR DESCRIPTION
Update the way lints are configured to use Rust's new `manifest-lint` feature.

**Status:** Ready

**Fixes:** N/A