### PR TITLE
Bring back the CI badge with the new URL scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # The Gram Programming Language
 
+[![Build status](https://github.com/gramlang/gram/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/gramlang/gram/actions?query=branch%3Amain)
+
 [Gram](https://www.gram.org) is a programming language for distributed systems.
 
 ## Installation instructions


### PR DESCRIPTION
Bring back the CI badge with the new URL scheme.

**Status:** Ready

**Fixes:** N/A