### PR TITLE
Update dependencies and Rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,8 +83,8 @@ jobs:
         #   https://github.com/rust-lang/rustup/issues/2441
         #
         # for more information.
-        rustup toolchain install 1.97.0 --no-self-update # [ref:rust_1.97.0]
-        rustup default 1.97.0 # [ref:rust_1.97.0]
+        rustup toolchain install 1.97.1 --no-self-update # [ref:rust_1.97.1]
+        rustup default 1.97.1 # [ref:rust_1.97.1]
 
         # Add the targets.
         rustup target add x86_64-pc-windows-msvc
@@ -124,8 +124,8 @@ jobs:
         set -euxo pipefail
 
         # Install the appropriate version of Rust.
-        rustup toolchain install 1.97.0 # [ref:rust_1.97.0]
-        rustup default 1.97.0 # [ref:rust_1.97.0]
+        rustup toolchain install 1.97.1 # [ref:rust_1.97.1]
+        rustup default 1.97.1 # [ref:rust_1.97.1]
 
         # Add the targets.
         rustup target add x86_64-apple-darwin
@@ -204,8 +204,8 @@ jobs:
         set -euxo pipefail
 
         # Install the appropriate version of Rust.
-        rustup toolchain install 1.97.0 # [ref:rust_1.97.0]
-        rustup default 1.97.0 # [ref:rust_1.97.0]
+        rustup toolchain install 1.97.1 # [ref:rust_1.97.1]
+        rustup default 1.97.1 # [ref:rust_1.97.1]
 
         # Fetch the program version.
         VERSION="$(cargo pkgid | cut -d# -f2 | cut -d: -f2)"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,15 +60,15 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -264,9 +264,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ clippy.pedantic = { level = "deny", priority = -1 }
 rust.warnings = "deny"
 
 [dependencies]
-clap = { version = "4.6.1", features = ["derive", "wrap_help"] }
+clap = { version = "4.6.2", features = ["derive", "wrap_help"] }
 clap_complete = "4.6.7"
 colored = "3.1.1"
 num-bigint = "0.5.1"

--- a/toast.yml
+++ b/toast.yml
@@ -17,11 +17,11 @@ command_prefix: |
   cargo-offline () { cargo --frozen --offline "$@"; }
 
   # Use this wrapper for formatting code or checking that code is formatted. We use a nightly Rust
-  # version for the `trailing_comma` formatting option [tag:rust_fmt_nightly_2026-07-09]. The
+  # version for the `trailing_comma` formatting option [tag:rust_fmt_nightly_2026-07-18]. The
   # nightly version was chosen as the latest available release with all components present
   # according to this page:
   #   https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu.html
-  cargo-fmt () { cargo +nightly-2026-07-09 --frozen --offline fmt --all -- "$@"; }
+  cargo-fmt () { cargo +nightly-2026-07-18 --frozen --offline fmt --all -- "$@"; }
 
   # Make Bash log commands.
   set -x
@@ -71,18 +71,18 @@ tasks:
       - install_packages
       - create_user
     command: |
-      # Install stable Rust [tag:rust_1.97.0].
+      # Install stable Rust [tag:rust_1.97.1].
       curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- \
         -y \
-        --default-toolchain 1.97.0 \
+        --default-toolchain 1.97.1 \
         --profile minimal \
         --component clippy
 
       # Add Rust tools to `$PATH`.
       . "$HOME/.cargo/env"
 
-      # Install nightly Rust [ref:rust_fmt_nightly_2026-07-09].
-      rustup toolchain install nightly-2026-07-09 --profile minimal --component rustfmt
+      # Install nightly Rust [ref:rust_fmt_nightly_2026-07-18].
+      rustup toolchain install nightly-2026-07-18 --profile minimal --component rustfmt
 
   install_tools:
     description: Install the tools needed to build and validate the program.


### PR DESCRIPTION
Updates dependencies and the pinned Rust toolchain.

Notable changes:

- Rust 1.97.0 -> 1.97.1
- rustfmt nightly 2026-07-09 -> 2026-07-18
- clap 4.6.1 -> 4.6.2

Changelog review: Rust 1.97.1 fixes an LLVM miscompilation; clap is a help-text patch. GitHub Actions, submodules, and LICENSE.md were already current.

**Status:** Ready

**Fixes:** N/A