### PR TITLE
Update dependencies and GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7.0.1
     - if: ${{ github.event_name == 'push' }}
-      uses: docker/login-action@v4.5.1
+      uses: docker/login-action@v4.6.0
       with:
         username: stephanmisc
         password: ${{ secrets.DOCKER_PASSWORD }}
@@ -190,7 +190,7 @@ jobs:
       contents: write
     steps:
     - uses: actions/checkout@v7.0.1
-    - uses: docker/login-action@v4.5.1
+    - uses: docker/login-action@v4.6.0
       with:
         username: stephanmisc
         password: ${{ secrets.DOCKER_PASSWORD }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,9 +66,9 @@ checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstream",
  "anstyle",
@@ -89,9 +89,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.7"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
+checksum = "b1f84a88507dbd05c695f2cb5e8558e747179134005e9893882dec964190ed89"
 dependencies = [
  "clap",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ clippy.pedantic = { level = "deny", priority = -1 }
 rust.warnings = "deny"
 
 [dependencies]
-clap = { version = "4.6.4", features = ["derive", "wrap_help"] }
-clap_complete = "4.6.7"
+clap = { version = "4.6.5", features = ["derive", "wrap_help"] }
+clap_complete = "4.6.8"
 colored = "3.1.1"
 num-bigint = "0.5.1"
 scopeguard = "1.2.0"


### PR DESCRIPTION
Update clap from 4.6.4 to 4.6.5, clap_complete from 4.6.7 to 4.6.8, and docker/login-action from 4.5.1 to 4.6.0. Rust and the 2026 copyright notice were already current.

**Status:** Ready

**Fixes:** N/A